### PR TITLE
fix: ensure primary/secondary color persists

### DIFF
--- a/packages/mirrorful/editor/src/components/ColorPalette/ColorPaletteSection.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/ColorPaletteSection.tsx
@@ -44,7 +44,7 @@ export function ColorPaletteSection({
 
                 newColors.forEach((color) => (color.isPrimary = false))
                 newColors[colorIndex].isPrimary = true
-                console.log(newColors)
+
                 onUpdateColors(newColors)
               }}
               onSetAsSecondary={() => {

--- a/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
@@ -1,5 +1,4 @@
 import {
-  Checkbox,
   Modal,
   ModalOverlay,
   ModalContent,
@@ -7,18 +6,15 @@ import {
   ModalFooter,
   ModalBody,
   ModalCloseButton,
-  Text,
   Button,
   FormControl,
   Input,
-  FormErrorMessage,
-  FormHelperText,
   FormLabel,
   Box,
   Flex,
 } from '@chakra-ui/react'
 import { TColorData } from 'types'
-import { useEffect, useState, useRef } from 'react'
+import { useState, useRef } from 'react'
 import { generateDefaultColorShades } from './utils'
 import { ColorPicker } from './ColorPicker'
 import { Color } from '@hello-pangea/color-picker'
@@ -51,12 +47,9 @@ export function EditColorModal({
   const [active, setActive] = useState<string | undefined>(
     initialColorData?.active
   )
-  const [isPrimary, setIsPrimary] = useState<boolean>(
-    initialColorData?.isPrimary ?? false
-  )
-  const [isSecondary, setIsSecondary] = useState<boolean>(
-    initialColorData?.isSecondary ?? false
-  )
+
+  const isPrimary = initialColorData?.isPrimary ?? false
+  const isSecondary = initialColorData?.isSecondary ?? false
 
   const [colorPickerColor, setColorPickerColor] = useState<Color>(
     initialColorData?.base ?? '#000000'
@@ -277,17 +270,6 @@ export function EditColorModal({
                 onBlur={onActiveBlur}
               />
             </FormControl>
-            {/* <FormControl css={{ marginTop: 16 }}>
-            <Checkbox
-              checked={!!isPrimary}
-              onChange={(event) => {
-                setIsPrimary(event.target.checked)
-              }}
-              defaultChecked={isPrimary}
-            >
-              This is the Primary
-            </Checkbox>
-          </FormControl> */}
           </Flex>
           {showBaseColorPicker && (
             <ColorPicker


### PR DESCRIPTION
# Summary

This PR fixes the primary/secondary color persistence issue reported in #31.

Current color editor behavior: https://www.loom.com/share/6a0c392eae12442d865b87058c33c030
Behavior with fixes in this PR: https://www.loom.com/share/50b6590fce7f49d68f859e224b5cabd6

# Description

`<EditColorModal />` has two stateful `isPrimary` and `isSecondary` values whose [initial values come from `initialColorData`](https://github.com/zachsnoek/mirrorful/blob/3c7fa2ede409c380d33031f5136d9a4dc5e405d5/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx#L54-L59). When the modal closes, [they get passed to `onClose`](https://github.com/zachsnoek/mirrorful/blob/3c7fa2ede409c380d33031f5136d9a4dc5e405d5/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx#L136-L137), which updates the color data.

When `color.isPrimary` and `color.isSecondary` get updated via the menu, the corresponding `<EditColorModal />` state isn't updated, so `onClose` gets called with their initial values, and we get the behavior shown above.

Since there isn't really a need for local `isPrimary` and `isSecondary` states in the modal currently, we can fix this by deriving the values from `initialColorData` instead.

I also removed some dead code and imports.