### PR TITLE
feat: add recommended shade buttons

### DIFF
--- a/packages/mirrorful/editor/src/components/ColorPalette/ColorPicker.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/ColorPicker.tsx
@@ -12,7 +12,15 @@ export function ColorPicker({
   onChange: (colorPickerColor: ColorResult, event: any) => void
 }) {
   return (
-    <Box width="250px">
+    <Box
+      sx={{
+        // HACK: `<SketchPicker />`'s `style` prop does a shallow merge,
+        //  so this lets us preserve the other `.sketch-picker` styles
+        '.sketch-picker': {
+          boxSizing: 'border-box !important',
+        },
+      }}
+    >
       <SketchPicker
         width="100%"
         color={colorPickerColor}

--- a/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
@@ -18,10 +18,9 @@ import {
 } from '@chakra-ui/react'
 import { TColorData } from 'types'
 import { useState, useRef } from 'react'
-import { generateDefaultColorShades } from './utils'
+import { generateDefaultColorShades, handleInvalidColor } from './utils'
 import { ColorPicker } from './ColorPicker'
 import { Color } from '@hello-pangea/color-picker'
-import { VALID_CSS_COLORS } from './validCssColors'
 import tinycolor from 'tinycolor2'
 import { FaMagic } from 'react-icons/fa'
 
@@ -68,38 +67,6 @@ export function EditColorModal({
   const shouldRecommendHover = !!base && !hover
   const shouldRecommendActive = !!base && !active
   const shades = generateDefaultColorShades(base)
-
-  const handleInvalidColor = (input: string) => {
-    // Check if input is a valid hex code
-    const hexRegex = /^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/
-    if (hexRegex.test(input)) {
-      if (input.startsWith('#')) {
-        return input
-      } else {
-        return `#${input}`
-      }
-    }
-
-    // Check if input is a valid color name
-    const lowerCaseInput = input.toLowerCase()
-    if (VALID_CSS_COLORS.includes(lowerCaseInput)) {
-      return lowerCaseInput
-    }
-
-    const validSubsetRegex = /^#?[0-9A-Fa-f]{0,6}$/ // regex to validate if input is a valid subset of a hexcode
-    const randomHex = Math.floor(Math.random() * 16777215).toString(16) // generate a random valid hexcode
-
-    if (validSubsetRegex.test(input)) {
-      // check if input is a valid subset of a hexcode
-      if (input.startsWith('#')) {
-        return `${input}${randomHex.slice(input.length - 1)}` // use input as the first part and append random characters as necessary to make a valid hexcode
-      } else {
-        return `#${input}${randomHex.slice(input.length)}` // use input as the first part and append random characters as necessary to make a valid hexcode
-      }
-    } else {
-      return `#${randomHex}` // generate a completely random valid hexcode
-    }
-  }
 
   const onBaseBlur = () => {
     const value = handleInvalidColor(base)

--- a/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
@@ -12,6 +12,9 @@ import {
   FormLabel,
   Box,
   Flex,
+  InputRightElement,
+  IconButton,
+  InputGroup,
 } from '@chakra-ui/react'
 import { TColorData } from 'types'
 import { useState, useRef } from 'react'
@@ -20,6 +23,7 @@ import { ColorPicker } from './ColorPicker'
 import { Color } from '@hello-pangea/color-picker'
 import { VALID_CSS_COLORS } from './validCssColors'
 import tinycolor from 'tinycolor2'
+import { FaMagic } from 'react-icons/fa'
 
 export function EditColorModal({
   isOpen,
@@ -60,6 +64,10 @@ export function EditColorModal({
     useState<boolean>(false)
   const [showActiveColorPicker, setShowActiveColorPicker] =
     useState<boolean>(false)
+
+  const shouldRecommendHover = !!base && !hover
+  const shouldRecommendActive = !!base && !active
+  const shades = generateDefaultColorShades(base)
 
   const handleInvalidColor = (input: string) => {
     // Check if input is a valid hex code
@@ -125,7 +133,7 @@ export function EditColorModal({
       base,
       hover,
       active,
-      shades: generateDefaultColorShades(base),
+      shades,
       isPrimary,
       isSecondary,
     })
@@ -215,26 +223,41 @@ export function EditColorModal({
                   />{' '}
                 </Box>
               </FormLabel>
-              <Input
-                ref={hoverRef}
-                placeholder="e.g. #D3AC3"
-                size="md"
-                value={hover}
-                onChange={(e) => setHover(e.target.value)}
-                onFocus={(e) => {
-                  setShowBaseColorPicker(false)
-                  setShowActiveColorPicker(false)
+              <InputGroup>
+                <Input
+                  ref={hoverRef}
+                  placeholder="e.g. #D3AC3"
+                  size="md"
+                  value={hover}
+                  onChange={(e) => setHover(e.target.value)}
+                  onFocus={(e) => {
+                    setShowBaseColorPicker(false)
+                    setShowActiveColorPicker(false)
 
-                  setColorPickerColor(e.target.value)
-                  setShowHoverColorPicker(true)
-                }}
-                onKeyPress={(event) => {
-                  if (event.key === 'Enter' && activeColorRef.current) {
-                    activeColorRef.current.focus()
-                  }
-                }}
-                onBlur={onHoverBlur}
-              />
+                    setColorPickerColor(e.target.value)
+                    setShowHoverColorPicker(true)
+                  }}
+                  onKeyPress={(event) => {
+                    if (event.key === 'Enter' && activeColorRef.current) {
+                      activeColorRef.current.focus()
+                    }
+                  }}
+                  onBlur={onHoverBlur}
+                />
+                <InputRightElement>
+                  {shouldRecommendHover && (
+                    <IconButton
+                      icon={<FaMagic />}
+                      onClick={() => {
+                        setColorPickerColor(shades['600'])
+                        setHover(shades['600'])
+                      }}
+                      size="sm"
+                      aria-label="Use recommended hover"
+                    />
+                  )}
+                </InputRightElement>
+              </InputGroup>
             </FormControl>
             <FormControl css={{ marginTop: 16 }}>
               <FormLabel>
@@ -249,26 +272,41 @@ export function EditColorModal({
                   />
                 </Box>
               </FormLabel>
-              <Input
-                ref={activeColorRef}
-                placeholder="e.g. #D3AC3"
-                size="md"
-                value={active}
-                onChange={(e) => setActive(e.target.value)}
-                onFocus={(e) => {
-                  setShowBaseColorPicker(false)
-                  setShowHoverColorPicker(false)
+              <InputGroup>
+                <Input
+                  ref={activeColorRef}
+                  placeholder="e.g. #D3AC3"
+                  size="md"
+                  value={active}
+                  onChange={(e) => setActive(e.target.value)}
+                  onFocus={(e) => {
+                    setShowBaseColorPicker(false)
+                    setShowHoverColorPicker(false)
 
-                  setColorPickerColor(e.target.value)
-                  setShowActiveColorPicker(true)
-                }}
-                onKeyPress={(event) => {
-                  if (event.key === 'Enter') {
-                    handleClose()
-                  }
-                }}
-                onBlur={onActiveBlur}
-              />
+                    setColorPickerColor(e.target.value)
+                    setShowActiveColorPicker(true)
+                  }}
+                  onKeyPress={(event) => {
+                    if (event.key === 'Enter') {
+                      handleClose()
+                    }
+                  }}
+                  onBlur={onActiveBlur}
+                />
+                <InputRightElement>
+                  {shouldRecommendActive && (
+                    <IconButton
+                      icon={<FaMagic />}
+                      onClick={() => {
+                        setColorPickerColor(shades['700'])
+                        setActive(shades['700'])
+                      }}
+                      size="sm"
+                      aria-label="Use recommended active"
+                    />
+                  )}
+                </InputRightElement>
+              </InputGroup>
             </FormControl>
           </Flex>
           {showBaseColorPicker && (

--- a/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
@@ -118,9 +118,10 @@ export function EditColorModal({
           css={{
             flexDirection: 'row',
             display: 'flex',
+            gap: 24,
           }}
         >
-          <Flex flexDirection="column" mr="10">
+          <Flex flexDirection="column" flex="1">
             <FormControl>
               <FormLabel>Variable Name</FormLabel>
               <Input
@@ -276,33 +277,35 @@ export function EditColorModal({
               </InputGroup>
             </FormControl>
           </Flex>
-          {showBaseColorPicker && (
-            <ColorPicker
-              onChange={(colorPickerColor, event) => {
-                setBase(colorPickerColor.hex)
-              }}
-              colorPickerColor={colorPickerColor}
-              presetColors={presetColors}
-            />
-          )}
-          {showHoverColorPicker && (
-            <ColorPicker
-              onChange={(colorPickerColor) => {
-                setHover(colorPickerColor.hex)
-              }}
-              colorPickerColor={colorPickerColor}
-              presetColors={presetColors}
-            />
-          )}
-          {showActiveColorPicker && (
-            <ColorPicker
-              onChange={(colorPickerColor) => {
-                setActive(colorPickerColor.hex)
-              }}
-              colorPickerColor={colorPickerColor}
-              presetColors={presetColors}
-            />
-          )}
+          <Box flex="1">
+            {showBaseColorPicker && (
+              <ColorPicker
+                onChange={(colorPickerColor, event) => {
+                  setBase(colorPickerColor.hex)
+                }}
+                colorPickerColor={colorPickerColor}
+                presetColors={presetColors}
+              />
+            )}
+            {showHoverColorPicker && (
+              <ColorPicker
+                onChange={(colorPickerColor) => {
+                  setHover(colorPickerColor.hex)
+                }}
+                colorPickerColor={colorPickerColor}
+                presetColors={presetColors}
+              />
+            )}
+            {showActiveColorPicker && (
+              <ColorPicker
+                onChange={(colorPickerColor) => {
+                  setActive(colorPickerColor.hex)
+                }}
+                colorPickerColor={colorPickerColor}
+                presetColors={presetColors}
+              />
+            )}
+          </Box>
         </ModalBody>
 
         <ModalFooter>

--- a/packages/mirrorful/editor/src/components/ColorPalette/utils.ts
+++ b/packages/mirrorful/editor/src/components/ColorPalette/utils.ts
@@ -1,4 +1,5 @@
 import tinycolor from 'tinycolor2'
+import { VALID_CSS_COLORS } from './validCssColors'
 
 export const newShade = (hexColor: string, magnitude: number) => {
   hexColor = hexColor.replace(`#`, ``)
@@ -49,5 +50,37 @@ export const generateDefaultColorShades = (primary: string) => {
     900: tinycolor(primary)
       .darken(scaleDiff * 4)
       .toHexString(),
+  }
+}
+
+export const handleInvalidColor = (input: string) => {
+  // Check if input is a valid hex code
+  const hexRegex = /^#?([0-9A-Fa-f]{3}|[0-9A-Fa-f]{6})$/
+  if (hexRegex.test(input)) {
+    if (input.startsWith('#')) {
+      return input
+    } else {
+      return `#${input}`
+    }
+  }
+
+  // Check if input is a valid color name
+  const lowerCaseInput = input.toLowerCase()
+  if (VALID_CSS_COLORS.includes(lowerCaseInput)) {
+    return lowerCaseInput
+  }
+
+  const validSubsetRegex = /^#?[0-9A-Fa-f]{0,6}$/ // regex to validate if input is a valid subset of a hexcode
+  const randomHex = Math.floor(Math.random() * 16777215).toString(16) // generate a random valid hexcode
+
+  if (validSubsetRegex.test(input)) {
+    // check if input is a valid subset of a hexcode
+    if (input.startsWith('#')) {
+      return `${input}${randomHex.slice(input.length - 1)}` // use input as the first part and append random characters as necessary to make a valid hexcode
+    } else {
+      return `#${input}${randomHex.slice(input.length)}` // use input as the first part and append random characters as necessary to make a valid hexcode
+    }
+  } else {
+    return `#${randomHex}` // generate a completely random valid hexcode
   }
 }


### PR DESCRIPTION
Demo: https://www.loom.com/share/d721fd16dcdd49fc8123c5ac4fa45bc9

This PR addresses #57: It adds magic wand icon buttons in the hover and active inputs, allowing users to fill the input with a recommended shade.

I also noticed that the `<ColorPicker />` alignment is a bit funky because the underlying `<SketchPicker />` has `box-sizing: content-box`. I changed it to `border-box` so that it's easier to work with and updated the modal layout to two equally-sized columns.