### PR TITLE
Change EditColorModal showBaseColorPicker default to true from false

### DIFF
--- a/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/EditColorModal.tsx
@@ -55,7 +55,7 @@ export function EditColorModal({
     initialColorData?.base ?? '#000000'
   )
 
-  const [showBaseColorPicker, setShowBaseColorPicker] = useState<boolean>(false)
+  const [showBaseColorPicker, setShowBaseColorPicker] = useState<boolean>(true)
   const [showHoverColorPicker, setShowHoverColorPicker] =
     useState<boolean>(false)
   const [showActiveColorPicker, setShowActiveColorPicker] =


### PR DESCRIPTION
**Summary**
Pull request to fix issue 66.  This PR changes setShowBaseColorPicker default from false to true, to ensure the colorpicker is displayed correctly when the edit color modal is opened.

**Description**
When a color in the editor is opened for edit, the EditColorModal doesn't initially display the colorpicker.  This is a result of no color (base / hover / active) being assigned to be displayed in the colorpicker.  This PR changes the `setShowBaseColorPicker` to default to true, thus ensuring that when the edit modal is displayed, the base color appears in the color picker.