### PR TITLE
resolves https://github.com/Mirrorful/mirrorful/issues/59

### DIFF
--- a/packages/mirrorful/editor/src/components/ColorPalette/ColorRow.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/ColorRow.tsx
@@ -371,7 +371,7 @@ export function ColorRow({
             ))}
           </Box>
         </Box>
-        <Stack css={{ marginLeft: '32px' }}>
+        <Stack css={{ marginLeft: '32px', width: '188px' }}>
           <Button
             css={{ marginTop: '16px' }}
             backgroundColor={colorData.base}
@@ -394,19 +394,21 @@ export function ColorRow({
           </Button>
           <Button
             leftIcon={<Icon as={FiAward} />}
+            isDisabled={colorData.isPrimary}
             onClick={() => {
               onSetAsPrimary()
             }}
           >
-            Set as Primary
+            {colorData.isPrimary ? 'Already Primary': 'Set as Primary'}
           </Button>
           <Button
             leftIcon={<Icon as={FiBookmark} />}
+            isDisabled={colorData.isSecondary}
             onClick={() => {
               onSetAsSecondary()
             }}
           >
-            Set as Secondary
+            {colorData.isSecondary ? 'Already Secondary': 'Set as Secondary'}
           </Button>
         </Stack>
       </Box>


### PR DESCRIPTION
Summary
Pull request to fix issue 59. This PR adds check for isPrimary and isSecondary on the buttons and changes text based on this condition.

Description
When a color is Set as Primary, it's attribute isPrimary is set to true, and based on this attribute, we disable the 'Set as Primary' button and also change it's text to 'Already Primary'. Same happens for Set as Secondary button.

Here's a small video showing how it looks on screen - 
https://watch.screencastify.com/v/tHwXBcOyT7rnnqppjffq