### PR TITLE
Issue #82 - Handle invalid colors in variant modals

### DIFF
--- a/packages/mirrorful/editor/src/components/ColorPalette/AddVariantModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/AddVariantModal.tsx
@@ -12,7 +12,7 @@ import {
   FormLabel,
   Box,
   Checkbox,
-  Text
+  Text,
 } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { TColorVariant } from 'types'
@@ -37,8 +37,8 @@ export function AddVariantModal({
 
   const handleSave = () => {
     // Save the submitted color value
-    const oldColor:string = variant.color
-    
+    const oldColor: string = variant.color
+
     // Check for blank / missing color
     if (!variant.color) {
       setError('Please enter a color.')
@@ -48,8 +48,7 @@ export function AddVariantModal({
     // If color is invalid, handleInvalidColor will reassign a value to the variant.color
     variant.color = handleInvalidColor(variant.color)
     // If there's a reassignment, they'll no longer match, so we can alert the user...
-    if(variant.color != oldColor)
-    {
+    if (variant.color !== oldColor) {
       setError('This is not a valid color')
       variant.color = oldColor
       return
@@ -98,7 +97,7 @@ export function AddVariantModal({
                 errorBorderColor="red.400"
                 isInvalid={!!error}
               />
-              { error && (
+              {error && (
                 <Text
                   css={{ alignSelf: 'flex-start', marginTop: '8px' }}
                   color="red.400"

--- a/packages/mirrorful/editor/src/components/ColorPalette/AddVariantModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/AddVariantModal.tsx
@@ -12,9 +12,11 @@ import {
   FormLabel,
   Box,
   Checkbox,
+  Text
 } from '@chakra-ui/react'
 import { useState, useEffect } from 'react'
 import { TColorVariant } from 'types'
+import { handleInvalidColor } from './utils'
 
 export function AddVariantModal({
   isOpen,
@@ -31,7 +33,29 @@ export function AddVariantModal({
     isBase: false,
   })
 
+  const [error, setError] = useState<string | null>(null)
+
   const handleSave = () => {
+    // Save the submitted color value
+    const oldColor:string = variant.color
+    
+    // Check for blank / missing color
+    if (!variant.color) {
+      setError('Please enter a color.')
+      return
+    }
+
+    // If color is invalid, handleInvalidColor will reassign a value to the variant.color
+    variant.color = handleInvalidColor(variant.color)
+    // If there's a reassignment, they'll no longer match, so we can alert the user...
+    if(variant.color != oldColor)
+    {
+      setError('This is not a valid color')
+      variant.color = oldColor
+      return
+    }
+    // Remove error so it doesn't persist...
+    setError(null)
     onAddVariant(variant)
     onClose()
   }
@@ -71,7 +95,18 @@ export function AddVariantModal({
                 onChange={(e) =>
                   setVariant({ ...variant, color: e.target.value })
                 }
+                errorBorderColor="red.400"
+                isInvalid={!!error}
               />
+              { error && (
+                <Text
+                  css={{ alignSelf: 'flex-start', marginTop: '8px' }}
+                  color="red.400"
+                  fontWeight="medium"
+                >
+                  {error}
+                </Text>
+              )}
             </FormControl>
           </Box>
         </ModalBody>

--- a/packages/mirrorful/editor/src/components/ColorPalette/EditVariantModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/EditVariantModal.tsx
@@ -12,9 +12,11 @@ import {
   FormLabel,
   Box,
   Checkbox,
+  Text
 } from '@chakra-ui/react'
 import { useState } from 'react'
 import { TColorVariant } from 'types'
+import { handleInvalidColor } from './utils'
 
 export function EditVariantModal({
   isOpen,
@@ -30,8 +32,29 @@ export function EditVariantModal({
   onDeleteVariant: () => void
 }) {
   const [variant, setVariant] = useState<TColorVariant>(initialVariant)
+  const [error, setError] = useState<string | null>(null)
 
   const handleSave = () => {
+    // Save the submitted color value
+    const oldColor:string = variant.color
+    
+    // Check for blank / missing color
+    if (!variant.color) {
+      setError('Please enter a color.')
+      return
+    }
+
+    // If color is invalid, handleInvalidColor will reassign a value to the variant.color
+    variant.color = handleInvalidColor(variant.color)
+    // If there's a reassignment, they'll no longer match, so we can alert the user...
+    if(variant.color != oldColor)
+    {
+      setError('This is not a valid color')
+      variant.color = oldColor
+      return
+    }
+    // Remove error so it doesn't persist...
+    setError(null)
     onUpdateVariant(variant)
     onClose()
   }
@@ -65,7 +88,18 @@ export function EditVariantModal({
                 onChange={(e) =>
                   setVariant({ ...variant, color: e.target.value })
                 }
+                errorBorderColor="red.400"
+                isInvalid={!!error}
               />
+              { error && (
+                <Text
+                  css={{ alignSelf: 'flex-start', marginTop: '8px' }}
+                  color="red.400"
+                  fontWeight="medium"
+                >
+                  {error}
+                </Text>
+              )}
             </FormControl>
             <FormControl css={{ marginTop: '32px' }}>
               <Checkbox

--- a/packages/mirrorful/editor/src/components/ColorPalette/EditVariantModal.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/EditVariantModal.tsx
@@ -12,7 +12,7 @@ import {
   FormLabel,
   Box,
   Checkbox,
-  Text
+  Text,
 } from '@chakra-ui/react'
 import { useState } from 'react'
 import { TColorVariant } from 'types'
@@ -36,8 +36,8 @@ export function EditVariantModal({
 
   const handleSave = () => {
     // Save the submitted color value
-    const oldColor:string = variant.color
-    
+    const oldColor: string = variant.color
+
     // Check for blank / missing color
     if (!variant.color) {
       setError('Please enter a color.')
@@ -47,8 +47,7 @@ export function EditVariantModal({
     // If color is invalid, handleInvalidColor will reassign a value to the variant.color
     variant.color = handleInvalidColor(variant.color)
     // If there's a reassignment, they'll no longer match, so we can alert the user...
-    if(variant.color != oldColor)
-    {
+    if (variant.color !== oldColor) {
       setError('This is not a valid color')
       variant.color = oldColor
       return
@@ -91,7 +90,7 @@ export function EditVariantModal({
                 errorBorderColor="red.400"
                 isInvalid={!!error}
               />
-              { error && (
+              {error && (
                 <Text
                   css={{ alignSelf: 'flex-start', marginTop: '8px' }}
                   color="red.400"


### PR DESCRIPTION
**Summary**
This PR is a fix for issue #82.  Previously, saving a new or edited variant color would permit, and save, invalid CSS color values.  This fix adds error checking and Input highlighting prior to save, following the same convention as in the onboarding name page.

**Description**
Implementation is the same in both the `AddVariantModal` and the `EditVariantModal` in that an error variable is created, and used to highlight incorrect / missing syntax on the color inputs within the modal.  A new Text Chakra component is added beneath each input to display relevant error message.

The validation is done by saving the initial value, and applying the handleInvalidCss util to the input color, then checking for differences, and setting the error message in the event that there is a difference (ie. the handleInvalidCss has changed the value).