### PR TITLE
Updated EditFontSizeModal variant value input to 'number' type

### DIFF
--- a/packages/mirrorful/editor/src/components/Typography/EditFontSizeModal.tsx
+++ b/packages/mirrorful/editor/src/components/Typography/EditFontSizeModal.tsx
@@ -89,6 +89,7 @@ export function EditFontSizeModal({
                 onChange={(e) =>
                   setVariant({ ...variant, value: Number(e.target.value) })
                 }
+                type='number'
               />
             </FormControl>
             <FormControl css={{ marginTop: '32px' }}>


### PR DESCRIPTION
Fixes #104 by updating the Chakra-ui Input to having type "number", which permits entering (only one) decimal place, which wasn't permitted previously.