### PR TITLE
Export object reshape

### DIFF
--- a/packages/mirrorful/editor/src/pages/api/export.ts
+++ b/packages/mirrorful/editor/src/pages/api/export.ts
@@ -58,12 +58,16 @@ const generateJsonFile = async ({ colorData, typography }: TTokens) => {
   let jsContent = `export const Tokens = `
   let jsonContent = ''
 
-  const themeObj = new Map<string, { [key: string]: string }>()
+  const themeObj = new Map<
+    string,
+    { [key: string]: string | { [key: string]: string } }
+  >()
 
+  const colorObj = new Map<string, { [key: string]: string }>()
   const fontSizeObj = new Map<string, string>()
 
   colorData.forEach((color) => {
-    themeObj.set(sanitizeName(color.name), {
+    colorObj.set(sanitizeName(color.name), {
       ...(color.baseColor && { base: color.baseColor }),
       ...color.variants,
     })
@@ -73,6 +77,7 @@ const generateJsonFile = async ({ colorData, typography }: TTokens) => {
     fontSizeObj.set(sanitizeName(color.name), `${color.value}${color.unit}`)
   })
 
+  themeObj.set('colors', Object.fromEntries(colorObj))
   themeObj.set('fontSizes', Object.fromEntries(fontSizeObj))
 
   const rawJsonObject = Object.fromEntries(themeObj)

--- a/packages/mirrorful/package.json
+++ b/packages/mirrorful/package.json
@@ -18,6 +18,7 @@
     "prepub": "rm -rf ./dist; npm version patch; tsc --build; cd editor; yarn build; cd .next; rm -rf cache; cd ../..;",
     "release:patch": "rm -rf ./dist; npm version patch; tsc --build; cd editor; yarn build; cd .next; rm -rf cache; cd ../..; npm publish;",
     "release:minor": "rm -rf ./dist; npm version minor; tsc --build; cd editor; yarn build; cd .next; rm -rf cache; cd ../..; npm publish;",
+    "release:major": "rm -rf ./dist; npm version major; tsc --build; cd editor; yarn build; cd .next; rm -rf cache; cd ../..; npm publish;",
     "testprod": "rm -rf ./dist; tsc --build; cd editor; yarn build; cd .next; rm -rf cache; cd ../..; npm link; echo '‼️ Now go to a test project and run npm link mirrorful; yarn run mirrorful'"
   },
   "repository": {


### PR DESCRIPTION
Resolves: https://github.com/Mirrorful/mirrorful/issues/108

Future food for thought:
We could expand this to a structure like:
```
{
   palette: {
      colors: {
          red: '#fffff",  
      },
     neutrals: {
         gray: '#d3d3d3',
     },
     alphas: {
         white: rgba(255, 255, 255, 0.3),
     },
  }
}
```