### PR TITLE
Added tailwind css option in the export modal

### DIFF
--- a/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
@@ -30,7 +30,7 @@ export function ExportSuccessModal({
   onClose: () => void
 }) {
   return (
-    <Modal isOpen={isOpen} onClose={onClose}>
+    <Modal size="lg" isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
         <ModalHeader>
@@ -52,14 +52,14 @@ export function ExportSuccessModal({
             <TabList>
               <Tab>CSS / SCSS</Tab>
               <Tab>Javascript / Typescript</Tab>
-              <Tab>Tailwind CSS</Tab>
+              <Tab>Tailwind</Tab>
             </TabList>
 
             <TabPanels>
               <TabPanel>
                 <Text css={{ marginBottom: 8 }}>
                   <span style={{ fontWeight: 'bold' }}>1.</span> Import{' '}
-                  <Code>theme.css</Code>
+                  <Code>theme.css</Code> (actual path may vary)
                 </Text>
                 <CodePreview
                   language="javascript"
@@ -101,22 +101,24 @@ export function ExportSuccessModal({
               <TabPanel>
                 <Text css={{ marginBottom: 8 }}>
                   <span style={{ fontWeight: 'bold' }}>1.</span> Import{' '}
-                  <Code>theme_cjs.js</Code> (actual path may vary) in <Code>tailwind.config.js</Code>
+                  <Code>theme_cjs.js</Code> (actual path may vary) in{' '}
+                  <Code>tailwind.config.js</Code>
                 </Text>
 
                 <CodePreview
                   language="javascript"
                   textClass="code-snippet"
-                  text={`const mirrorful = require('./.mirrorful/theme_cjs.js')`}
+                  text={`const { Tokens } = require('./.mirrorful/theme_cjs.js')`}
                 />
 
                 <Text css={{ marginTop: 12, marginBottom: 8 }}>
-                  <span style={{ fontWeight: 'bold' }}>2.</span> Extend the tailwind theme.
+                  <span style={{ fontWeight: 'bold' }}>2.</span> Extend the
+                  tailwind theme.
                 </Text>
                 <CodePreview
                   language="javascript"
                   textClass="code-snippet"
-                  text={`theme: {\n    extend: { colors: mirrorful.Tokens.colors } \n}`}
+                  text={`theme: {\n    extend: { colors: Tokens.colors } \n}`}
                 />
               </TabPanel>
             </TabPanels>

--- a/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
@@ -52,6 +52,7 @@ export function ExportSuccessModal({
             <TabList>
               <Tab>CSS / SCSS</Tab>
               <Tab>Javascript / Typescript</Tab>
+              <Tab>Tailwind CSS</Tab>
             </TabList>
 
             <TabPanels>
@@ -95,6 +96,27 @@ export function ExportSuccessModal({
                   language="javascript"
                   textClass="code-snippet"
                   text={`<button\n   style={{ backgroundColor: Tokens.primary.base}}\n> Click here\n</button>`}
+                />
+              </TabPanel>
+              <TabPanel>
+                <Text css={{ marginBottom: 8 }}>
+                  <span style={{ fontWeight: 'bold' }}>1.</span> Import{' '}
+                  <Code>theme_cjs.js</Code> (actual path may vary) in <Code>tailwind.config.js</Code>
+                </Text>
+
+                <CodePreview
+                  language="javascript"
+                  textClass="code-snippet"
+                  text={`const mirrorful = require('./.mirrorful/theme_cjs.js')`}
+                />
+
+                <Text css={{ marginTop: 12, marginBottom: 8 }}>
+                  <span style={{ fontWeight: 'bold' }}>2.</span> Extend the tailwind theme.
+                </Text>
+                <CodePreview
+                  language="javascript"
+                  textClass="code-snippet"
+                  text={`theme: {\n    extend: { colors: mirrorful.Tokens.colors } \n}`}
                 />
               </TabPanel>
             </TabPanels>

--- a/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
@@ -32,7 +32,7 @@ export function ImportInstructions({
     <Box css={{ display: 'flex', height: '100%' }}>
       <Box
         css={{
-          width: '50%',
+          width: '40%',
           padding: '12px',
           display: 'flex',
           flexDirection: 'column',
@@ -96,24 +96,25 @@ export function ImportInstructions({
       </Box>
       <Box
         css={{
-          width: '50%',
+          width: '60%',
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
-          padding: '64px',
+          padding: '40px',
         }}
       >
         <Tabs>
           <TabList>
             <Tab>CSS / SCSS</Tab>
             <Tab>Javascript / Typescript</Tab>
+            <Tab>Tailwind</Tab>
           </TabList>
 
           <TabPanels>
             <TabPanel>
               <Text css={{ marginBottom: 8 }}>
                 <span style={{ fontWeight: 'bold' }}>1.</span> Import{' '}
-                <Code>theme.css</Code>
+                <Code>theme.css</Code> (actual path may vary)
               </Text>
               <CodePreview
                 language="javascript"
@@ -133,7 +134,7 @@ export function ImportInstructions({
             <TabPanel>
               <Text css={{ marginBottom: 8 }}>
                 <span style={{ fontWeight: 'bold' }}>1.</span> Import{' '}
-                <Code>Tokens</Code>
+                <Code>Tokens</Code> (actual path may vary)
               </Text>
 
               <CodePreview
@@ -150,6 +151,29 @@ export function ImportInstructions({
                 language="javascript"
                 textClass="code-snippet"
                 text={`<button\n   style={{ backgroundColor: Tokens.primary.base}}\n> Click here\n</button>`}
+              />
+            </TabPanel>
+            <TabPanel>
+              <Text css={{ marginBottom: 8 }}>
+                <span style={{ fontWeight: 'bold' }}>1.</span> Import{' '}
+                <Code>theme_cjs.js</Code> (actual path may vary) in{' '}
+                <Code>tailwind.config.js</Code>
+              </Text>
+
+              <CodePreview
+                language="javascript"
+                textClass="code-snippet"
+                text={`const { Tokens } = require('./.mirrorful/theme_cjs.js')`}
+              />
+
+              <Text css={{ marginTop: 12, marginBottom: 8 }}>
+                <span style={{ fontWeight: 'bold' }}>2.</span> Extend the
+                tailwind theme.
+              </Text>
+              <CodePreview
+                language="javascript"
+                textClass="code-snippet"
+                text={`theme: {\n    extend: { colors: Tokens.colors } \n}`}
               />
             </TabPanel>
           </TabPanels>


### PR DESCRIPTION
Resolves: [#115 ](https://github.com/Mirrorful/mirrorful/issues/115)

- Added option & instructions for tailwind css in the export modal