### PR TITLE
Remove leading zeros when deleting a variant value

### DIFF
--- a/packages/mirrorful/editor/src/components/Typography/EditFontSizeModal.tsx
+++ b/packages/mirrorful/editor/src/components/Typography/EditFontSizeModal.tsx
@@ -87,9 +87,9 @@ export function EditFontSizeModal({
               <Input
                 value={variant.value}
                 onChange={(e) =>
-                  setVariant({ ...variant, value: Number(e.target.value) })
+                  setVariant({ ...variant, value: e.target.value })
                 }
-                type='number'
+                type="number"
               />
             </FormControl>
             <FormControl css={{ marginTop: '32px' }}>


### PR DESCRIPTION
While I was on issue #113 I noticed that it was tricky to edit the variant value. Whenever you delete the current value it add a zero to the left. Here is an example: 
<img width="588" alt="Screen Shot 2023-03-13 at 4 13 36 PM" src="https://user-images.githubusercontent.com/57118300/224833760-72263ae6-6911-4eb9-96dd-114acbeb6122.png">

With this update, the user would be able to edit the variant value without getting a zero at the left of the input field. It would look like this instead. 
<img width="590" alt="Screen Shot 2023-03-13 at 4 16 02 PM" src="https://user-images.githubusercontent.com/57118300/224834175-35a26ab6-f5c8-4e21-99cb-cc5981e28648.png">
