### PR TITLE
feat: add files property to configuration object

### DIFF
--- a/packages/mirrorful/editor/src/store/migrations.ts
+++ b/packages/mirrorful/editor/src/store/migrations.ts
@@ -1,7 +1,7 @@
 import Conf from 'conf'
-import { TColorData, TTypographyData } from 'types'
+import { TColorData, TConfig, TTypographyData } from 'types'
 
-export const ZeroPointZeroPointTwoMigration = (store: Conf<any>) => {
+export const ZeroPointZeroPointTwoMigration = (store: Conf<TConfig>) => {
   const tokens = store.get('tokens')
 
   let newTokens: {
@@ -62,10 +62,16 @@ export const defaultTypography: TTypographyData = {
   ],
 }
 
-export const ZeroPointZeroPointThreeMigration = (store: Conf<any>) => {
+export const ZeroPointZeroPointThreeMigration = (store: Conf<TConfig>) => {
   const tokens = store.get('tokens')
   const updatedTokens = { ...tokens }
 
   updatedTokens.typography = defaultTypography
   store.set('tokens', updatedTokens)
+}
+
+export const defaultFiles: TConfig['files'] = ['css', 'scss', 'js', 'ts']
+
+export const ZeroPointZeroPointFourMigration = (store: Conf<TConfig>) => {
+  store.set('files', defaultFiles)
 }

--- a/packages/mirrorful/editor/src/store/store.ts
+++ b/packages/mirrorful/editor/src/store/store.ts
@@ -1,9 +1,11 @@
 import Conf from 'conf'
-import { TTokens } from 'types'
+import { TConfig } from 'types'
 import {
   ZeroPointZeroPointTwoMigration,
   ZeroPointZeroPointThreeMigration,
   defaultTypography,
+  ZeroPointZeroPointFourMigration,
+  defaultFiles,
 } from './migrations'
 
 // Our working directory is 2 levels below node_modules in production, so we go up 3 levels
@@ -12,15 +14,16 @@ export const rootPath =
     ? '../.mirrorful'
     : '../../../.mirrorful'
 
-export const store = new Conf<{ tokens: TTokens }>({
+export const store = new Conf<TConfig>({
   projectName: 'Mirrorful',
-  projectVersion: '0.0.3',
+  projectVersion: '0.0.4',
   cwd: `${rootPath}/store`,
   defaults: {
     tokens: {
       colorData: [],
       typography: defaultTypography,
     },
+    files: defaultFiles,
   },
   beforeEachMigration: (store, context) => {
     console.log(
@@ -30,5 +33,6 @@ export const store = new Conf<{ tokens: TTokens }>({
   migrations: {
     '0.0.2': ZeroPointZeroPointTwoMigration,
     '0.0.3': ZeroPointZeroPointThreeMigration,
+    '0.0.4': ZeroPointZeroPointFourMigration,
   },
 })

--- a/packages/mirrorful/editor/src/types.ts
+++ b/packages/mirrorful/editor/src/types.ts
@@ -26,3 +26,10 @@ export type TTokens = {
   colorData: TColorData[]
   typography: TTypographyData
 }
+
+export type TExportFileType = 'css' | 'scss' | 'js' | 'ts'
+
+export type TConfig = {
+  tokens: TTokens
+  files: TExportFileType[]
+}


### PR DESCRIPTION
## Summary

This PR sets us up for letting users select which file types to export (#147). It adds a `files` property to the configuration object and a corresponding migration. In my next PR, we'll add an input in the editor for setting this property and only export to the specified files.

## Testing

Manual testing: Exported to a configuration file at the migration version `0.0.3` and ensured that the migration version was incremented and a `files` property was created.