### PR TITLE
refactor: add file type translators

### DIFF
--- a/packages/mirrorful/editor/src/pages/api/export.ts
+++ b/packages/mirrorful/editor/src/pages/api/export.ts
@@ -1,96 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import fs from 'fs'
-import { TColorData, TTokens } from 'types'
+import { TExportFileType, TTokens } from 'types'
 import { rootPath, store } from 'store/store'
-
-const sanitizeName = (name: string | number) => {
-  return `${name}`.toLowerCase().split(' ').join('-')
-}
-const getKeys = Object.keys as <T extends object>(obj: T) => Array<keyof T>
+import { translators } from 'translators'
 
 const generateStorageFile = async ({ colorData, typography }: TTokens) => {
   store.set('tokens', { colorData, typography })
-}
-
-const generateCssFile = async ({ colorData, typography }: TTokens) => {
-  let scssContent = ``
-  let cssContent = `:root {\n`
-
-  colorData.forEach((color) => {
-    if (color.baseColor) {
-      scssContent += `$color-${sanitizeName(color.name)}: ${color.baseColor};\n`
-      cssContent += `  --color-${sanitizeName(color.name)}: ${
-        color.baseColor
-      };\n`
-    }
-
-    getKeys(color.variants).forEach((key) => {
-      if (color.variants[key]) {
-        scssContent += `$color-${sanitizeName(color.name)}-${sanitizeName(
-          key
-        )}: ${color.variants[key]};\n`
-        cssContent += `  --color-${sanitizeName(color.name)}-${sanitizeName(
-          key
-        )}: ${color.variants[key]};\n`
-      }
-    })
-  })
-
-  typography.fontSizes.forEach((fontSize) => {
-    scssContent += `$font-size-${sanitizeName(fontSize.name)}: ${
-      fontSize.value
-    }${fontSize.unit};\n`
-    cssContent += `  --font-size-${sanitizeName(fontSize.name)}: ${
-      fontSize.value
-    }${fontSize.unit};\n`
-  })
-
-  cssContent += `}\n`
-  scssContent += `\n${cssContent}`
-
-  await fs.writeFileSync(`${rootPath}/theme.css`, cssContent)
-  await fs.writeFileSync(`${rootPath}/theme.scss`, scssContent)
-}
-
-const generateJsonFile = async ({ colorData, typography }: TTokens) => {
-  let tsContent = `export const Tokens = `
-  let cjsContent = `exports.Tokens = `
-  let jsContent = `export const Tokens = `
-  let jsonContent = ''
-
-  const themeObj = new Map<
-    string,
-    { [key: string]: string | { [key: string]: string } }
-  >()
-
-  const colorObj = new Map<string, { [key: string]: string }>()
-  const fontSizeObj = new Map<string, string>()
-
-  colorData.forEach((color) => {
-    colorObj.set(sanitizeName(color.name), {
-      ...(color.baseColor && { base: color.baseColor }),
-      ...color.variants,
-    })
-  })
-
-  typography.fontSizes.forEach((color) => {
-    fontSizeObj.set(sanitizeName(color.name), `${color.value}${color.unit}`)
-  })
-
-  themeObj.set('colors', Object.fromEntries(colorObj))
-  themeObj.set('fontSizes', Object.fromEntries(fontSizeObj))
-
-  const rawJsonObject = Object.fromEntries(themeObj)
-
-  tsContent += JSON.stringify(rawJsonObject, null, 2)
-  jsContent += JSON.stringify(rawJsonObject, null, 2)
-  cjsContent += JSON.stringify(rawJsonObject, null, 2)
-  jsonContent += JSON.stringify(rawJsonObject, null, 2)
-
-  await fs.writeFileSync(`${rootPath}/theme_cjs.js`, cjsContent)
-  await fs.writeFileSync(`${rootPath}/theme.js`, jsContent)
-  await fs.writeFileSync(`${rootPath}/theme.ts`, tsContent)
-  await fs.writeFileSync(`${rootPath}/theme.json`, jsonContent)
 }
 
 export default async function handler(
@@ -103,14 +18,15 @@ export default async function handler(
     colorData: body.colorData,
     typography: body.typography,
   })
-  await generateCssFile({
-    colorData: body.colorData,
-    typography: body.typography,
-  })
-  await generateJsonFile({
-    colorData: body.colorData,
-    typography: body.typography,
-  })
+
+  for (const fileType in translators) {
+    const translator = translators[fileType as TExportFileType]
+
+    const fileName = `${rootPath}/theme${translator.extension}`
+    const content = translator.toContent(body)
+
+    fs.writeFileSync(fileName, content)
+  }
 
   return res.status(200).json({ message: 'Success' })
 }

--- a/packages/mirrorful/editor/src/store/migrations.ts
+++ b/packages/mirrorful/editor/src/store/migrations.ts
@@ -70,7 +70,14 @@ export const ZeroPointZeroPointThreeMigration = (store: Conf<TConfig>) => {
   store.set('tokens', updatedTokens)
 }
 
-export const defaultFiles: TConfig['files'] = ['css', 'scss', 'js', 'ts']
+export const defaultFiles: TConfig['files'] = [
+  'css',
+  'scss',
+  'js',
+  'cjs',
+  'ts',
+  'json',
+]
 
 export const ZeroPointZeroPointFourMigration = (store: Conf<TConfig>) => {
   store.set('files', defaultFiles)

--- a/packages/mirrorful/editor/src/translators/createThemeObject.ts
+++ b/packages/mirrorful/editor/src/translators/createThemeObject.ts
@@ -1,0 +1,30 @@
+import { TTokens } from 'types'
+import { sanitizeName } from './sanitizeName'
+
+export function createThemeObject({ colorData, typography }: TTokens) {
+  const themeObj = new Map<
+    string,
+    { [key: string]: string | { [key: string]: string } }
+  >()
+
+  const colorObj = new Map<string, { [key: string]: string }>()
+  const fontSizeObj = new Map<string, string>()
+
+  colorData.forEach((color) => {
+    colorObj.set(sanitizeName(color.name), {
+      ...(color.baseColor && { base: color.baseColor }),
+      ...color.variants,
+    })
+  })
+
+  typography.fontSizes.forEach((color) => {
+    fontSizeObj.set(sanitizeName(color.name), `${color.value}${color.unit}`)
+  })
+
+  themeObj.set('colors', Object.fromEntries(colorObj))
+  themeObj.set('fontSizes', Object.fromEntries(fontSizeObj))
+
+  const rawJsonObject = Object.fromEntries(themeObj)
+
+  return rawJsonObject
+}

--- a/packages/mirrorful/editor/src/translators/index.ts
+++ b/packages/mirrorful/editor/src/translators/index.ts
@@ -1,0 +1,33 @@
+import { toCjs } from './toCjs'
+import { toCss } from './toCss'
+import { toJs } from './toJs'
+import { toJson } from './toJson'
+import { toScss } from './toScss'
+import { TranslatorMap } from './types'
+
+export const translators: TranslatorMap = {
+  css: {
+    toContent: toCss,
+    extension: '.css',
+  },
+  scss: {
+    toContent: toScss,
+    extension: '.scss',
+  },
+  js: {
+    toContent: toJs,
+    extension: '.js',
+  },
+  cjs: {
+    toContent: toCjs,
+    extension: '_cjs.js',
+  },
+  ts: {
+    toContent: toJs,
+    extension: '.ts',
+  },
+  json: {
+    toContent: toJson,
+    extension: '.json',
+  },
+}

--- a/packages/mirrorful/editor/src/translators/sanitizeName.ts
+++ b/packages/mirrorful/editor/src/translators/sanitizeName.ts
@@ -1,0 +1,3 @@
+export function sanitizeName(name: string | number) {
+  return `${name}`.toLowerCase().split(' ').join('-')
+}

--- a/packages/mirrorful/editor/src/translators/toCjs.ts
+++ b/packages/mirrorful/editor/src/translators/toCjs.ts
@@ -1,0 +1,6 @@
+import { TTokens } from 'types'
+import { toJson } from './toJson'
+
+export const toCjs = (tokens: TTokens): string => {
+  return 'exports.Tokens = ' + toJson(tokens)
+}

--- a/packages/mirrorful/editor/src/translators/toCss.ts
+++ b/packages/mirrorful/editor/src/translators/toCss.ts
@@ -1,0 +1,35 @@
+import { TTokens } from 'types'
+import { getKeys } from 'utils/getKeys'
+import { sanitizeName } from './sanitizeName'
+
+export const toCss = ({ colorData, typography }: TTokens): string => {
+  const content = [':root {']
+
+  colorData.forEach((color) => {
+    if (color.baseColor) {
+      content.push(`  --color-${sanitizeName(color.name)}: ${color.baseColor};`)
+    }
+
+    getKeys(color.variants).forEach((key) => {
+      if (color.variants[key]) {
+        content.push(
+          `  --color-${sanitizeName(color.name)}-${sanitizeName(key)}: ${
+            color.variants[key]
+          };`
+        )
+      }
+    })
+  })
+
+  typography.fontSizes.forEach((fontSize) => {
+    content.push(
+      `  --font-size-${sanitizeName(fontSize.name)}: ${fontSize.value}${
+        fontSize.unit
+      };`
+    )
+  })
+
+  content.push(`}`)
+
+  return content.join('\n')
+}

--- a/packages/mirrorful/editor/src/translators/toJs.ts
+++ b/packages/mirrorful/editor/src/translators/toJs.ts
@@ -1,0 +1,6 @@
+import { TTokens } from 'types'
+import { toJson } from './toJson'
+
+export const toJs = (tokens: TTokens): string => {
+  return 'export const Tokens = ' + toJson(tokens)
+}

--- a/packages/mirrorful/editor/src/translators/toJson.ts
+++ b/packages/mirrorful/editor/src/translators/toJson.ts
@@ -1,0 +1,6 @@
+import { TTokens } from 'types'
+import { createThemeObject } from './createThemeObject'
+
+export const toJson = (tokens: TTokens): string => {
+  return JSON.stringify(createThemeObject(tokens), null, 2)
+}

--- a/packages/mirrorful/editor/src/translators/toScss.ts
+++ b/packages/mirrorful/editor/src/translators/toScss.ts
@@ -30,7 +30,7 @@ export const toScss = ({ colorData, typography }: TTokens): string => {
     )
   })
 
-  content.push(toCss({ colorData, typography }))
+  content.push('', toCss({ colorData, typography }))
 
   return content.join('\n')
 }

--- a/packages/mirrorful/editor/src/translators/toScss.ts
+++ b/packages/mirrorful/editor/src/translators/toScss.ts
@@ -1,0 +1,36 @@
+import { TTokens } from 'types'
+import { getKeys } from 'utils/getKeys'
+import { sanitizeName } from './sanitizeName'
+import { toCss } from './toCss'
+
+export const toScss = ({ colorData, typography }: TTokens): string => {
+  const content: string[] = []
+
+  colorData.forEach((color) => {
+    if (color.baseColor) {
+      content.push(`$color-${sanitizeName(color.name)}: ${color.baseColor};`)
+    }
+
+    getKeys(color.variants).forEach((key) => {
+      if (color.variants[key]) {
+        content.push(
+          `$color-${sanitizeName(color.name)}-${sanitizeName(key)}: ${
+            color.variants[key]
+          };`
+        )
+      }
+    })
+  })
+
+  typography.fontSizes.forEach((fontSize) => {
+    content.push(
+      `$font-size-${sanitizeName(fontSize.name)}: ${fontSize.value}${
+        fontSize.unit
+      };`
+    )
+  })
+
+  content.push(toCss({ colorData, typography }))
+
+  return content.join('\n')
+}

--- a/packages/mirrorful/editor/src/translators/types.ts
+++ b/packages/mirrorful/editor/src/translators/types.ts
@@ -1,0 +1,8 @@
+import { TExportFileType, TTokens } from 'types'
+
+export type Translator = {
+  toContent: (tokens: TTokens) => string
+  extension: string
+}
+
+export type TranslatorMap = { [FileType in TExportFileType]: Translator }

--- a/packages/mirrorful/editor/src/types.ts
+++ b/packages/mirrorful/editor/src/types.ts
@@ -27,7 +27,7 @@ export type TTokens = {
   typography: TTypographyData
 }
 
-export type TExportFileType = 'css' | 'scss' | 'js' | 'ts'
+export type TExportFileType = 'css' | 'scss' | 'js' | 'cjs' | 'ts' | 'json'
 
 export type TConfig = {
   tokens: TTokens

--- a/packages/mirrorful/editor/src/utils/getKeys.ts
+++ b/packages/mirrorful/editor/src/utils/getKeys.ts
@@ -1,0 +1,3 @@
+export const getKeys = Object.keys as <T extends object>(
+  obj: T
+) => Array<keyof T>


### PR DESCRIPTION
# Summary

Currently, two file generation functions in the export API handler are responsible for generating all six token files. While this works fine now, it'll become hard to navigate and maintain ~if~ when we start supporting more export types. The current implementation also makes it more difficult to generate specific file types.

Instead, we should have functions that handle the content translation for each file type. This PR introduces translator functions for the six file types and replaces the current handler implementation. These signatures are probably incomplete but should be enough to help us add new export types more quickly, and with my next PR (addressing #147), that will use the config to determine which files to generate.

# Notes

The easiest way to review this is by reviewing each commit.

I noticed that the current file generation functions are `async` but using `fs.writeFileSync`. I kept the `toContent` functions synchronous for now, but in the future, we might want to make them `async`, map them to Promises, then `Promise.all` them in the handler.

Lastly, these changes will help me address #155 more easily 😉.

# Testing

I exported my config manually and ensured the refactored code generated the same files. Please double-check and confirm that the output has stayed the same!