### PR TITLE
Replaced hardcoded color name from onboarding and export modal by actual color name

### DIFF
--- a/packages/mirrorful/editor/src/components/Dashboard.tsx
+++ b/packages/mirrorful/editor/src/components/Dashboard.tsx
@@ -142,6 +142,7 @@ export function Dashboard() {
       </Box>
       <Box css={{ marginBottom: '64px' }} />
       <ExportSuccessModal
+        primaryName={colors && colors[0] ? colors[0].name : 'primary'}
         isOpen={isExportSuccessModalOpen}
         onClose={onExportSuccessModalClose}
       />

--- a/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
@@ -101,7 +101,7 @@ export function ExportSuccessModal({
                 <CodePreview
                   language="javascript"
                   textClass="code-snippet"
-                  text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName}.base}}\n> Click here\n</button>`}
+                  text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName}.base }}\n> Click here\n</button>`}
                 />
               </TabPanel>
               <TabPanel>

--- a/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
@@ -23,9 +23,11 @@ import 'highlight.js/styles/atom-one-dark.css'
 import { CodePreview } from './CodePreview'
 
 export function ExportSuccessModal({
+  primaryName,
   isOpen,
   onClose,
 }: {
+  primaryName: string
   isOpen: boolean
   onClose: () => void
 }) {
@@ -75,7 +77,7 @@ export function ExportSuccessModal({
                 <CodePreview
                   language="css"
                   textClass="code-snippet"
-                  text={`.primary-button {\n    background-color: var(--color-primary);\n}\n\n.primary-button:hover {\n    background-color: var(--color-primary-hover);\n}`}
+                  text={`.${primaryName}-button {\n    background-color: var(--color-${primaryName});\n}\n\n.${primaryName}-button:hover {\n    background-color: var(--color-${primaryName}-hover);\n}`}
                 />
               </TabPanel>
               <TabPanel>
@@ -99,7 +101,7 @@ export function ExportSuccessModal({
                 <CodePreview
                   language="javascript"
                   textClass="code-snippet"
-                  text={`<button\n   style={{ backgroundColor: Tokens.primary.base}}\n> Click here\n</button>`}
+                  text={`<button\n   style={{ backgroundColor: Tokens.${primaryName}.base}}\n> Click here\n</button>`}
                 />
               </TabPanel>
               <TabPanel>

--- a/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
@@ -77,7 +77,7 @@ export function ExportSuccessModal({
                 <CodePreview
                   language="css"
                   textClass="code-snippet"
-                  text={`.${primaryName}-button {\n    background-color: var(--color-${primaryName});\n}\n\n.${primaryName}-button:hover {\n    background-color: var(--color-${primaryName}-hover);\n}`}
+                  text={`.${primaryName.toLowerCase()}-button {\n    background-color: var(--color-${primaryName.toLowerCase()});\n}\n\n.${primaryName.toLowerCase()}-button:hover {\n    background-color: var(--color-${primaryName.toLowerCase()}-hover);\n}`}
                 />
               </TabPanel>
               <TabPanel>
@@ -101,7 +101,7 @@ export function ExportSuccessModal({
                 <CodePreview
                   language="javascript"
                   textClass="code-snippet"
-                  text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName}.base }}\n> Click here\n</button>`}
+                  text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName.toLowerCase()}.base }}\n> Click here\n</button>`}
                 />
               </TabPanel>
               <TabPanel>

--- a/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSuccessModal.tsx
@@ -101,7 +101,7 @@ export function ExportSuccessModal({
                 <CodePreview
                   language="javascript"
                   textClass="code-snippet"
-                  text={`<button\n   style={{ backgroundColor: Tokens.${primaryName}.base}}\n> Click here\n</button>`}
+                  text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName}.base}}\n> Click here\n</button>`}
                 />
               </TabPanel>
               <TabPanel>

--- a/packages/mirrorful/editor/src/components/Onboarding/index.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/index.tsx
@@ -93,6 +93,7 @@ export function Onboarding({
     content = (
       <ImportInstructions
         primaryColor={primaryColor}
+        primaryName={primaryName}
         onUpdatePage={setPage}
         onFinish={onFinishOnboarding}
       />

--- a/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
@@ -131,7 +131,7 @@ export function ImportInstructions({
               <CodePreview
                 language="css"
                 textClass="code-snippet"
-                text={`.${primaryName}-button {\n    background-color: var(--color-${primaryName});\n}\n\n.${primaryName}-button:hover {\n    background-color: var(--color-${primaryName}-hover);\n}`}
+                text={`.${primaryName.toLowerCase()}-button {\n    background-color: var(--color-${primaryName.toLowerCase()});\n}\n\n.${primaryName.toLowerCase()}-button:hover {\n    background-color: var(--color-${primaryName.toLowerCase()}-hover);\n}`}
               />
             </TabPanel>
             <TabPanel>
@@ -154,7 +154,7 @@ export function ImportInstructions({
               <CodePreview
                 language="javascript"
                 textClass="code-snippet"
-                text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName}.base }}\n> Click here\n</button>`}
+                text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName.toLowerCase()}.base }}\n> Click here\n</button>`}
               />
             </TabPanel>
             <TabPanel>

--- a/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
@@ -154,7 +154,7 @@ export function ImportInstructions({
               <CodePreview
                 language="javascript"
                 textClass="code-snippet"
-                text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName}.base}}\n> Click here\n</button>`}
+                text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName}.base }}\n> Click here\n</button>`}
               />
             </TabPanel>
             <TabPanel>

--- a/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
@@ -19,10 +19,12 @@ import { CodePreview } from 'components/CodePreview'
 
 export function ImportInstructions({
   primaryColor,
+  primaryName,
   onUpdatePage,
   onFinish,
 }: {
   primaryColor: string
+  primaryName: string
   onUpdatePage: (page: number) => void
   onFinish: () => void
 }) {
@@ -129,7 +131,7 @@ export function ImportInstructions({
               <CodePreview
                 language="css"
                 textClass="code-snippet"
-                text={`.primary-button {\n    background-color: var(--color-primary);\n}\n\n.primary-button:hover {\n    background-color: var(--color-primary-hover);\n}`}
+                text={`.${primaryName}-button {\n    background-color: var(--color-${primaryName});\n}\n\n.${primaryName}-button:hover {\n    background-color: var(--color-${primaryName}-hover);\n}`}
               />
             </TabPanel>
             <TabPanel>
@@ -152,7 +154,7 @@ export function ImportInstructions({
               <CodePreview
                 language="javascript"
                 textClass="code-snippet"
-                text={`<button\n   style={{ backgroundColor: Tokens.primary.base}}\n> Click here\n</button>`}
+                text={`<button\n   style={{ backgroundColor: Tokens.${primaryName}.base}}\n> Click here\n</button>`}
               />
             </TabPanel>
             <TabPanel>

--- a/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/pages/ImportInstructions.tsx
@@ -154,7 +154,7 @@ export function ImportInstructions({
               <CodePreview
                 language="javascript"
                 textClass="code-snippet"
-                text={`<button\n   style={{ backgroundColor: Tokens.${primaryName}.base}}\n> Click here\n</button>`}
+                text={`<button\n   style={{ backgroundColor: Tokens.colors.${primaryName}.base}}\n> Click here\n</button>`}
               />
             </TabPanel>
             <TabPanel>


### PR DESCRIPTION
Resolves: [#157  ](https://github.com/Mirrorful/mirrorful/issues/157)

- replaced hardcoded primary color name from onboarding and export modal by actual color name see by user
- fixed deprecated tokens usage synatx and structured it as per mirrorful v4.0.0 release

Reference:
[Loom Video](https://www.loom.com/share/22673c9ec4cc4600bac9e0b01bc0f0f9)