### PR TITLE
feat: add ability to select export files

### DIFF
--- a/packages/mirrorful/editor/src/components/Dashboard.tsx
+++ b/packages/mirrorful/editor/src/components/Dashboard.tsx
@@ -50,8 +50,7 @@ export function Dashboard() {
     await fetch('/api/export', {
       method: 'POST',
       body: JSON.stringify({
-        colorData: colors,
-        typography,
+        tokens: { colorData: colors, typography },
       }),
     })
 
@@ -63,8 +62,10 @@ export function Dashboard() {
     await fetch('/api/export', {
       method: 'POST',
       body: JSON.stringify({
-        typography,
-        colorData: data,
+        tokens: {
+          typography,
+          colorData: data,
+        },
       }),
     })
   }
@@ -74,8 +75,7 @@ export function Dashboard() {
     await fetch('/api/export', {
       method: 'POST',
       body: JSON.stringify({
-        colorData: colors,
-        typography: data,
+        tokens: { colorData: colors, typography: data },
       }),
     })
   }

--- a/packages/mirrorful/editor/src/components/Dashboard.tsx
+++ b/packages/mirrorful/editor/src/components/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useDisclosure, Box, Button } from '@chakra-ui/react'
 import { useEffect, useState } from 'react'
-import { TColorData, TTypographyData } from 'types'
+import { TColorData, TConfig, TTypographyData } from 'types'
 import { ColorPaletteSection } from './ColorPalette/ColorPaletteSection'
 import { ExportSuccessModal } from './ExportSuccessModal'
 import { Onboarding } from './Onboarding'
@@ -26,12 +26,19 @@ export function Dashboard() {
   useEffect(() => {
     const fetchStoredData = async () => {
       const response = await fetch('/api/config')
-      const data = await response.json()
-      if (!data || !data.colorData || data.colorData.length === 0) {
+      const data: TConfig | undefined = await response.json()
+
+      if (
+        !data ||
+        !data.tokens.colorData ||
+        data.tokens.colorData.length === 0
+      ) {
         setShowOnboarding(true)
+        return
       }
-      setColors(data.colorData ?? [])
-      setTypography(data.typography)
+
+      setColors(data.tokens.colorData ?? [])
+      setTypography(data.tokens.typography)
     }
 
     fetchStoredData()

--- a/packages/mirrorful/editor/src/components/ExportSettingsModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSettingsModal.tsx
@@ -8,7 +8,6 @@ import {
   ModalCloseButton,
   Button,
   CheckboxGroup,
-  SimpleGrid,
   Checkbox,
   Heading,
   VStack,

--- a/packages/mirrorful/editor/src/components/ExportSettingsModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSettingsModal.tsx
@@ -1,0 +1,67 @@
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  Button,
+  CheckboxGroup,
+  SimpleGrid,
+  Checkbox,
+  Heading,
+  VStack,
+  Flex,
+} from '@chakra-ui/react'
+import { defaultFiles } from 'store/migrations'
+import { TExportFileType } from 'types'
+import { getExportFileTypeName } from 'utils/getExportFileTypeString'
+
+type Props = {
+  isOpen: boolean
+  onClose: () => void
+  fileTypes: TExportFileType[]
+  onUpdateFileTypes: (next: TExportFileType[]) => void
+}
+
+export function ExportSettingsModal({
+  isOpen,
+  onClose,
+  fileTypes,
+  onUpdateFileTypes,
+}: Props) {
+  return (
+    <Modal size="lg" isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Export Settings</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Flex direction="column" gap={3}>
+            <Heading size="sm" as="label">
+              File Types
+            </Heading>
+            <CheckboxGroup
+              defaultValue={fileTypes}
+              onChange={onUpdateFileTypes}
+            >
+              <VStack alignItems="flex-start">
+                {defaultFiles.map((x) => (
+                  <Checkbox key={x} value={x}>
+                    {getExportFileTypeName(x)}
+                  </Checkbox>
+                ))}
+              </VStack>
+            </CheckboxGroup>
+          </Flex>
+        </ModalBody>
+        <ModalFooter>
+          <Button onClick={onClose} colorScheme="blue">
+            Done
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/packages/mirrorful/editor/src/components/ExportSettingsModal.tsx
+++ b/packages/mirrorful/editor/src/components/ExportSettingsModal.tsx
@@ -38,9 +38,7 @@ export function ExportSettingsModal({
         <ModalCloseButton />
         <ModalBody>
           <Flex direction="column" gap={3}>
-            <Heading size="sm" as="label">
-              File Types
-            </Heading>
+            <Heading size="sm">File Types</Heading>
             <CheckboxGroup
               defaultValue={fileTypes}
               onChange={onUpdateFileTypes}

--- a/packages/mirrorful/editor/src/components/Onboarding/constants.ts
+++ b/packages/mirrorful/editor/src/components/Onboarding/constants.ts
@@ -1,1 +1,1 @@
-export const NUMBER_OF_STEPS_IN_NEW_FLOW = `05`
+export const NUMBER_OF_STEPS_IN_NEW_FLOW = `06`

--- a/packages/mirrorful/editor/src/components/Onboarding/index.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/index.tsx
@@ -40,8 +40,7 @@ export function Onboarding({
     await fetch('/api/export', {
       method: 'POST',
       body: JSON.stringify({
-        colorData: colors,
-        typography: defaultTypography,
+        tokens: { colorData: colors, typography: defaultTypography },
       }),
     })
   }

--- a/packages/mirrorful/editor/src/components/Onboarding/index.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/index.tsx
@@ -1,9 +1,7 @@
-import { Box, Heading, Text } from '@chakra-ui/react'
 import { generateDefaultColorShades } from 'components/ColorPalette/utils'
 import { useState } from 'react'
-import { defaultTypography } from 'store/migrations'
+import { defaultFiles, defaultTypography } from 'store/migrations'
 import { TColorData } from 'types'
-import { OnboardingCard } from './OnboardingCard'
 import { OnboardingContainer } from './OnboardingContainer'
 import { ImportInstructions } from './pages/ImportInstructions'
 import { NamePrimary } from './pages/NamePrimary'
@@ -41,6 +39,7 @@ export function Onboarding({
       method: 'POST',
       body: JSON.stringify({
         tokens: { colorData: colors, typography: defaultTypography },
+        files: defaultFiles,
       }),
     })
   }

--- a/packages/mirrorful/editor/src/components/Onboarding/index.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/index.tsx
@@ -1,8 +1,9 @@
 import { generateDefaultColorShades } from 'components/ColorPalette/utils'
 import { useState } from 'react'
 import { defaultFiles, defaultTypography } from 'store/migrations'
-import { TColorData } from 'types'
+import { TColorData, TExportFileType } from 'types'
 import { OnboardingContainer } from './OnboardingContainer'
+import { ExportSettings } from './pages/ExportSettings'
 import { ImportInstructions } from './pages/ImportInstructions'
 import { NamePrimary } from './pages/NamePrimary'
 import { OtherColors } from './pages/OtherColors'
@@ -18,6 +19,7 @@ export function Onboarding({
   const [primaryColor, setPrimaryColor] = useState<string>('#9F7AEA')
   const [primaryName, setPrimaryName] = useState<string>('')
   const [palette, setPalette] = useState<TColorData[]>([])
+  const [fileTypes, setFileTypes] = useState<TExportFileType[]>(defaultFiles)
 
   const [page, setPage] = useState<number>(0)
 
@@ -39,7 +41,7 @@ export function Onboarding({
       method: 'POST',
       body: JSON.stringify({
         tokens: { colorData: colors, typography: defaultTypography },
-        files: defaultFiles,
+        files: fileTypes,
       }),
     })
   }
@@ -79,7 +81,6 @@ export function Onboarding({
               color.variants = generateDefaultColorShades(color.baseColor)
             }
           })
-          handleExport(primaryColor, primaryName, newPalette)
           setPalette(newPalette)
         }}
         primaryColor={primaryColor}
@@ -88,6 +89,18 @@ export function Onboarding({
       />
     )
   } else if (page === 5) {
+    content = (
+      <ExportSettings
+        primaryColor={primaryColor}
+        fileTypes={fileTypes}
+        onUpdateFileTypes={setFileTypes}
+        onExport={() => {
+          handleExport(primaryColor, primaryName, palette)
+        }}
+        onUpdatePage={setPage}
+      />
+    )
+  } else if (page === 6) {
     content = (
       <ImportInstructions
         primaryColor={primaryColor}

--- a/packages/mirrorful/editor/src/components/Onboarding/pages/ExportSettings.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/pages/ExportSettings.tsx
@@ -36,15 +36,13 @@ export function ExportSettings({
   return (
     <Box css={{ display: 'flex', height: '100%' }}>
       <Box
-        css={{
-          width: '50%',
-          padding: '12px',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'space-between',
-        }}
+        width="50%"
+        padding="12px"
+        display="flex"
+        flexDirection="column"
+        justifyContent="space-between"
       >
-        <Box css={{ paddingTop: '32px' }}>
+        <Box paddingTop="32px">
           <Stack spacing={1} direction={'row'}>
             <Text color="gray.500" fontWeight="black" fontSize={18}>
               05
@@ -56,20 +54,19 @@ export function ExportSettings({
               {NUMBER_OF_STEPS_IN_NEW_FLOW}
             </Text>
           </Stack>
-
-          <Heading fontWeight="black" css={{ marginTop: '12px' }} fontSize={36}>
+          <Heading fontWeight="black" marginTop="12px" fontSize={36}>
             Choose your export files.
           </Heading>
           <Text
-            css={{ marginTop: '32px' }}
+            marginTop="32px"
             fontSize={20}
             color="gray.500"
             fontWeight="bold"
           >
-            These are the token file formats that Mirrorful will export.
+            These are the token files that Mirrorful will export.
           </Text>
         </Box>
-        <Box css={{ paddingBottom: '32px' }}>
+        <Box paddingBottom="32px">
           <Button
             bgColor={shades['500']}
             color={tinycolor(primaryColor).isDark() ? 'white' : 'black'}
@@ -79,7 +76,7 @@ export function ExportSettings({
             _active={{
               bgColor: shades['800'],
             }}
-            padding={'8px 36px'}
+            padding="8px 36px"
             size="lg"
             rightIcon={<ArrowForwardIcon />}
             onClick={() => {
@@ -93,13 +90,11 @@ export function ExportSettings({
         </Box>
       </Box>
       <Box
-        css={{
-          width: '50%',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-          padding: '64px',
-        }}
+        width="50%"
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        padding="64px"
       >
         <CheckboxGroup defaultValue={fileTypes} onChange={onUpdateFileTypes}>
           <VStack alignItems="flex-start">

--- a/packages/mirrorful/editor/src/components/Onboarding/pages/ExportSettings.tsx
+++ b/packages/mirrorful/editor/src/components/Onboarding/pages/ExportSettings.tsx
@@ -1,0 +1,116 @@
+import { ArrowForwardIcon } from '@chakra-ui/icons'
+import {
+  Box,
+  Stack,
+  Text,
+  Heading,
+  Button,
+  CheckboxGroup,
+  VStack,
+  Checkbox,
+} from '@chakra-ui/react'
+import { generateDefaultColorShades } from 'components/ColorPalette/utils'
+import { defaultFiles } from 'store/migrations'
+import tinycolor from 'tinycolor2'
+import { TExportFileType } from 'types'
+import { getExportFileTypeName } from 'utils/getExportFileTypeString'
+import { NUMBER_OF_STEPS_IN_NEW_FLOW } from '../constants'
+
+type Props = {
+  primaryColor: string
+  fileTypes: TExportFileType[]
+  onUpdateFileTypes: (next: TExportFileType[]) => void
+  onExport: () => void
+  onUpdatePage: (page: number) => void
+}
+
+export function ExportSettings({
+  primaryColor,
+  fileTypes,
+  onUpdateFileTypes,
+  onExport,
+  onUpdatePage,
+}: Props) {
+  const shades = generateDefaultColorShades(primaryColor)
+
+  return (
+    <Box css={{ display: 'flex', height: '100%' }}>
+      <Box
+        css={{
+          width: '50%',
+          padding: '12px',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+        }}
+      >
+        <Box css={{ paddingTop: '32px' }}>
+          <Stack spacing={1} direction={'row'}>
+            <Text color="gray.500" fontWeight="black" fontSize={18}>
+              05
+            </Text>
+            <Text color="gray.500" fontWeight="bold" fontSize={18}>
+              of
+            </Text>
+            <Text color="gray.500" fontWeight="black" fontSize={18}>
+              {NUMBER_OF_STEPS_IN_NEW_FLOW}
+            </Text>
+          </Stack>
+
+          <Heading fontWeight="black" css={{ marginTop: '12px' }} fontSize={36}>
+            Choose your export files.
+          </Heading>
+          <Text
+            css={{ marginTop: '32px' }}
+            fontSize={20}
+            color="gray.500"
+            fontWeight="bold"
+          >
+            These are the token file formats that Mirrorful will export.
+          </Text>
+        </Box>
+        <Box css={{ paddingBottom: '32px' }}>
+          <Button
+            bgColor={shades['500']}
+            color={tinycolor(primaryColor).isDark() ? 'white' : 'black'}
+            _hover={{
+              bgColor: shades['700'],
+            }}
+            _active={{
+              bgColor: shades['800'],
+            }}
+            padding={'8px 36px'}
+            size="lg"
+            rightIcon={<ArrowForwardIcon />}
+            onClick={() => {
+              onExport()
+              onUpdatePage(6)
+            }}
+            isDisabled={!fileTypes.length}
+          >
+            Next
+          </Button>
+        </Box>
+      </Box>
+      <Box
+        css={{
+          width: '50%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          padding: '64px',
+        }}
+      >
+        <CheckboxGroup defaultValue={fileTypes} onChange={onUpdateFileTypes}>
+          <VStack alignItems="flex-start">
+            {defaultFiles.map((x) => (
+              <Checkbox key={x} value={x}>
+                {getExportFileTypeName(x)}
+              </Checkbox>
+            ))}
+          </VStack>
+        </CheckboxGroup>
+      </Box>
+    </Box>
+  )
+}

--- a/packages/mirrorful/editor/src/pages/api/config.ts
+++ b/packages/mirrorful/editor/src/pages/api/config.ts
@@ -1,6 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import fs from 'fs'
 import { rootPath, store } from '../../store/store'
+import { TConfig } from 'types'
 
 const readStorageFile = async (): Promise<{ colorData: string[] }> => {
   const data = await fs.promises.readFile(`${rootPath}/store.json`, 'utf8')
@@ -16,13 +17,14 @@ const deleteStorageFile = async () => {
 }
 
 export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
+  _: NextApiRequest,
+  res: NextApiResponse<TConfig>
 ) {
-  const tokens = store.get('tokens')
+  const config = store.store
 
   // Handle migration from old storage file
   try {
+    const tokens = store.get('tokens')
     const data = await readStorageFile()
     if (
       data.colorData &&
@@ -31,11 +33,11 @@ export default async function handler(
     ) {
       store.set('tokens', data)
       deleteStorageFile()
-      return res.status(200).json(data)
+      return res.status(200).json(config)
     }
   } catch (e) {
     console.log('No migration needed!')
   }
 
-  return res.status(200).json(tokens)
+  return res.status(200).json(config)
 }

--- a/packages/mirrorful/editor/src/pages/api/config.ts
+++ b/packages/mirrorful/editor/src/pages/api/config.ts
@@ -16,11 +16,15 @@ const deleteStorageFile = async () => {
   }
 }
 
+type TInternalConfig = TConfig & {
+  __internal__: Record<string, unknown>
+}
+
 export default async function handler(
   _: NextApiRequest,
   res: NextApiResponse<TConfig>
 ) {
-  const config = store.store
+  const { __internal__, ...config } = store.store as TInternalConfig
 
   // Handle migration from old storage file
   try {

--- a/packages/mirrorful/editor/src/pages/api/export.ts
+++ b/packages/mirrorful/editor/src/pages/api/export.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import fs from 'fs'
-import { TExportFileType, TTokens } from 'types'
+import { TConfig, TExportFileType, TTokens } from 'types'
 import { rootPath, store } from 'store/store'
 import { translators } from 'translators'
 
@@ -12,18 +12,19 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const body = JSON.parse(req.body)
+  const body = JSON.parse(req.body) as TConfig // TODO: Validate request body
+  const { tokens } = body
 
   await generateStorageFile({
-    colorData: body.colorData,
-    typography: body.typography,
+    colorData: tokens.colorData,
+    typography: tokens.typography,
   })
 
   for (const fileType in translators) {
     const translator = translators[fileType as TExportFileType]
 
     const fileName = `${rootPath}/theme${translator.extension}`
-    const content = translator.toContent(body)
+    const content = translator.toContent(tokens)
 
     fs.writeFileSync(fileName, content)
   }

--- a/packages/mirrorful/editor/src/pages/api/export.ts
+++ b/packages/mirrorful/editor/src/pages/api/export.ts
@@ -1,30 +1,27 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import fs from 'fs'
-import { TConfig, TExportFileType, TTokens } from 'types'
+import { TConfig, TExportFileType } from 'types'
 import { rootPath, store } from 'store/store'
 import { translators } from 'translators'
 
-const generateStorageFile = async ({ colorData, typography }: TTokens) => {
-  store.set('tokens', { colorData, typography })
+const generateStorageFile = async ({ tokens, files }: TConfig) => {
+  store.set('tokens', tokens)
+  store.set('files', files)
 }
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  const body = JSON.parse(req.body) as TConfig // TODO: Validate request body
-  const { tokens } = body
+  const config = JSON.parse(req.body) as TConfig // TODO: Validate request body
 
-  await generateStorageFile({
-    colorData: tokens.colorData,
-    typography: tokens.typography,
-  })
+  await generateStorageFile(config)
 
-  for (const fileType in translators) {
+  for (const fileType of config.files) {
     const translator = translators[fileType as TExportFileType]
 
     const fileName = `${rootPath}/theme${translator.extension}`
-    const content = translator.toContent(tokens)
+    const content = translator.toContent(config.tokens)
 
     fs.writeFileSync(fileName, content)
   }

--- a/packages/mirrorful/editor/src/utils/getExportFileTypeString.ts
+++ b/packages/mirrorful/editor/src/utils/getExportFileTypeString.ts
@@ -1,0 +1,14 @@
+import { TExportFileType } from 'types'
+
+const fileTypeToString: { [x in TExportFileType]: string } = {
+  css: 'CSS',
+  scss: 'Sass',
+  js: 'JavaScript',
+  cjs: 'CommonJS',
+  ts: 'TypeScript',
+  json: 'JSON',
+}
+
+export function getExportFileTypeName(fileType: TExportFileType): string {
+  return fileTypeToString[fileType] ?? `${fileType}`
+}


### PR DESCRIPTION
# Summary

This PR resolves #147: It lets users select only the file types they want to be exported!

[Demo](https://drive.google.com/file/d/1j1gGfNc1pCTTrLyHK7gCDJcX274Nk_2T/view?usp=share_link) (Ugh, sorry for the Google Drive link.)

**UI changes**:
* Added an export settings modal that has a file type section for selecting export files
* Added a settings button to open the export settings modal
* Added a step to the onboarding flow for selecting file types so that the user starts with only the files they need

**API changes**:
* `/api/config` now returns the config object, not just the tokens
* `/api/export` now accepts the config object, not just the tokens

# Testing

* Manually tested creating a new Mirrorful config from scratch (see demo video above) and exporting tokens
* Manually tested updating file types with an existing Mirrorful config and exporting tokens: only the selected file types should get updated, and the other files should remain untouched

# Notes

* Note that currently, Mirrorful won't delete token files if the user removes an export file type, so existing projects can consider manually deleting the unneeded files if they remove export file types.
* Obligatory: This is primarily a duct tape implementation. I see a lot of opportunities for refactoring (e.g., updating state management and creating reusable components), but this is good enough for now™️.