### PR TITLE
fix: max font size in preview

### DIFF
--- a/packages/mirrorful/editor/src/components/Typography/FontSizeRow.tsx
+++ b/packages/mirrorful/editor/src/components/Typography/FontSizeRow.tsx
@@ -3,18 +3,16 @@ import { Box, Stack, Text, Button, useDisclosure } from '@chakra-ui/react'
 import { EditFontSizeModal } from './EditFontSizeModal'
 
 export function calculateMaxFontSizeForPreview(fontSizeData: TFontSizeVariant) {
-  // allow anything up to 6rem
-  if (fontSizeData.unit === 'rem') {
-    return `${Math.min(fontSizeData.value, 6)}rem`
-  }
   // allow anything up to 96px
   if (fontSizeData.unit === 'px') {
     return `${Math.min(fontSizeData.value, 96)}px`
   }
-  // allow anything up to 6em
-  if (fontSizeData.unit === 'em') {
-    return `${Math.min(fontSizeData.value, 6)}em`
+
+  // allow anything up to 6rem || 6em
+  if (fontSizeData.unit === 'rem' || fontSizeData.unit === 'em') {
+    return `${Math.min(fontSizeData.value, 6)}${fontSizeData.unit}`
   }
+
   return '1rem'
 }
 

--- a/packages/mirrorful/editor/src/components/Typography/FontSizeRow.tsx
+++ b/packages/mirrorful/editor/src/components/Typography/FontSizeRow.tsx
@@ -2,7 +2,7 @@ import { TFontSizeVariant } from 'types'
 import { Box, Stack, Text, Button, useDisclosure } from '@chakra-ui/react'
 import { EditFontSizeModal } from './EditFontSizeModal'
 
-export function calculateMaxFontSizeForPreview(fontSizeData: TFontSizeVariant) {
+function calculateMaxFontSizeForPreview(fontSizeData: TFontSizeVariant) {
   // allow anything up to 96px
   if (fontSizeData.unit === 'px') {
     return `${Math.min(fontSizeData.value, 96)}px`

--- a/packages/mirrorful/editor/src/components/Typography/FontSizeRow.tsx
+++ b/packages/mirrorful/editor/src/components/Typography/FontSizeRow.tsx
@@ -2,6 +2,22 @@ import { TFontSizeVariant } from 'types'
 import { Box, Stack, Text, Button, useDisclosure } from '@chakra-ui/react'
 import { EditFontSizeModal } from './EditFontSizeModal'
 
+export function calculateMaxFontSizeForPreview(fontSizeData: TFontSizeVariant) {
+  // allow anything up to 6rem
+  if (fontSizeData.unit === 'rem') {
+    return `${Math.min(fontSizeData.value, 6)}rem`
+  }
+  // allow anything up to 96px
+  if (fontSizeData.unit === 'px') {
+    return `${Math.min(fontSizeData.value, 96)}px`
+  }
+  // allow anything up to 6em
+  if (fontSizeData.unit === 'em') {
+    return `${Math.min(fontSizeData.value, 6)}em`
+  }
+  return '1rem'
+}
+
 export function FontSizeRow({
   fontSizeData,
   onUpdateFontSizeVariant,
@@ -44,7 +60,7 @@ export function FontSizeRow({
         </Box>
         <Box
           css={{
-            fontSize: `${fontSizeData.value}${fontSizeData.unit}`,
+            fontSize: calculateMaxFontSizeForPreview(fontSizeData),
             width: 700,
           }}
         >


### PR DESCRIPTION
Fixes: #170 

- Adds a function that limits the fontSize to 6rem, 6em and 96px for the FontSizeRow component preview