### PR TITLE
sort color values by lightness

### DIFF
--- a/packages/mirrorful/editor/src/components/ColorPalette/ColorDisplay.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/ColorDisplay.tsx
@@ -221,7 +221,12 @@ export function ColorDisplay({
         <Box css={{ marginTop: '32px' }}>
           <Stack spacing={'4px'}>
             {Object.keys(colorData.variants)
-              .sort()
+              .sort((a, b) =>
+                tinycolor(colorData.variants[a]).toHsl().l <
+                tinycolor(colorData.variants[b]).toHsl().l
+                  ? 1
+                  : -1
+              )
               .map((variant) => (
                 <VariantRow
                   key={variant}


### PR DESCRIPTION
resolves #176 

<img width="1680" alt="Screenshot 2023-03-18 at 11 40 19" src="https://user-images.githubusercontent.com/82717216/226100545-7fb8a4f9-23cf-42af-9f1a-0485571d4c10.png">

# Notes
This pr sorts the lightness of a variant and sets up a base case. Extreme cases like adding a completely different color to a variant hasn't been taking into account yet.