### PR TITLE
Update styling of base color variant - fixes #107

### DIFF
--- a/packages/mirrorful/editor/src/components/ColorPalette/ColorDisplay.tsx
+++ b/packages/mirrorful/editor/src/components/ColorPalette/ColorDisplay.tsx
@@ -46,20 +46,20 @@ function VariantRow({
         justifyContent: 'space-between',
         padding: '0px 24px',
         borderRadius: 8,
-        border: '1px solid black',
+        border: variant.isBase ? '2px solid black' : '1px solid black',
       }}
     >
       <Text
         fontSize="1rem"
-        fontWeight={600}
+        fontWeight={variant.isBase ? 700 : 600}
         color={tinycolor(variant.color).isDark() ? 'white' : 'black'}
       >
-        {name}
+        {name} {variant.isBase ? ' (Base)' : ''}
       </Text>
       <Box css={{ display: 'flex', alignItems: 'center' }}>
         <Text
           fontSize="1rem"
-          fontWeight={600}
+          fontWeight={variant.isBase ? 700 : 600}
           color={tinycolor(variant.color).isDark() ? 'white' : 'black'}
         >
           {color}
@@ -228,7 +228,9 @@ export function ColorDisplay({
                   variant={{
                     name: variant,
                     color: colorData.variants[variant],
-                    isBase: colorData.variants[variant] === colorData.baseColor,
+                    isBase:
+                      colorData.variants[variant].toUpperCase() ===
+                      colorData.baseColor.toUpperCase(),
                   }}
                   onUpdateVariant={(newVariant: TColorVariant) => {
                     const updatedVariants = { ...colorData.variants }


### PR DESCRIPTION
Change styling of variant to highlight if it matches base - bolder font, thicker border, text indicating 'base'.  Update base comparison so that all colors are upper-cased for comparison.  Proposed fix for issue #107.