### PR TITLE
Fix Color Section over sidebar issue

### DIFF
--- a/packages/core/src/components/Dashboard/index.tsx
+++ b/packages/core/src/components/Dashboard/index.tsx
@@ -27,7 +27,7 @@ export function Dashboard({
   postStoreData: (data: TConfig) => Promise<void>
   platform?: TPlatform
 }) {
-  const [tab, setTab] = useState<'colors' | 'typography'>('colors')
+  const [tab, setTab] = useState<TTab>('colors')
   const [shouldForceSkipOnboarding, setShouldForceSkipOnboarding] =
     useState<boolean>(false)
 
@@ -124,9 +124,7 @@ export function Dashboard({
         />
       </Box>
       <Box css={{ minWidth: '300px' }} />
-      <Box
-        css={{ flexGrow: 1, backgroundColor: 'white', padding: '64px 128px' }}
-      >
+      <Box css={{ backgroundColor: 'white', padding: '64px 128px' }}>
         {tab === 'colors' && (
           <ColorPaletteSection
             colors={colors}

--- a/packages/core/src/components/ExportSettingsModal.tsx
+++ b/packages/core/src/components/ExportSettingsModal.tsx
@@ -13,7 +13,6 @@ import {
   ModalOverlay,
   VStack,
 } from '@chakra-ui/react'
-// import { defaultFiles } from 'store/migrations'
 import { TExportFileType } from '@core/types'
 import { getExportFileTypeName } from '@core/utils/getExportFileTypeString'
 


### PR DESCRIPTION
Not sure why flexGrow was there originally?

With flexGrow: 

![image](https://user-images.githubusercontent.com/29822597/227076173-a3eabcc0-db3d-40e4-820b-047a7b13e392.png)
