### PR TITLE
refactor: use JSON5 to stringify theme object

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "@emotion/styled": "^11.10.6",
     "@hello-pangea/color-picker": "^3.2.2",
     "framer-motion": "^10.6.0",
+    "json5": "^2.2.3",
     "lottie-react": "^2.4.0",
     "posthog-js": "^1.51.3",
     "react": "^18.2.0",
@@ -36,6 +37,7 @@
   },
   "devDependencies": {
     "@mirrorful/eslint-config": "file:../eslint-config",
+    "@types/json5": "^2.2.0",
     "@types/node": "^18.15.3",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",

--- a/packages/core/src/translators/toCjs.ts
+++ b/packages/core/src/translators/toCjs.ts
@@ -1,7 +1,9 @@
 import { TTokens } from '@core/types'
+import JSON5 from 'json5'
 
-import { toJson } from './toJson'
+import { createThemeObject } from './createThemeObject'
 
 export const toCjs = (tokens: TTokens): string => {
-  return 'exports.Tokens = ' + toJson(tokens)
+  const theme = createThemeObject(tokens)
+  return 'exports.Tokens = ' + JSON5.stringify(theme, { space: 2 })
 }

--- a/packages/core/src/translators/toJs.ts
+++ b/packages/core/src/translators/toJs.ts
@@ -1,7 +1,9 @@
 import { TTokens } from '@core/types'
+import JSON5 from 'json5'
 
-import { toJson } from './toJson'
+import { createThemeObject } from './createThemeObject'
 
 export const toJs = (tokens: TTokens): string => {
-  return 'export const Tokens = ' + toJson(tokens)
+  const theme = createThemeObject(tokens)
+  return 'export const Tokens = ' + JSON5.stringify(theme, { space: 2 })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1331,6 +1331,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/json5@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-2.2.0.tgz#afff29abf9182a7d4a7e39105ca051f11c603d13"
+  integrity sha512-NrVug5woqbvNZ0WX+Gv4R+L4TGddtmFek2u8RtccAgFZWtS9QXF2xCXY22/M4nzkaKF0q9Fc6M/5rxLDhfwc/A==
+  dependencies:
+    json5 "*"
+
 "@types/lodash.mergewith@4.6.7":
   version "4.6.7"
   resolved "https://registry.yarnpkg.com/@types/lodash.mergewith/-/lodash.mergewith-4.6.7.tgz#eaa65aa5872abdd282f271eae447b115b2757212"
@@ -3293,6 +3300,11 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+json5@*, json5@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
+  integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
 json5@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Resolves #155.

---

This PR replaces `JSON.stringify` with `JSON5.stringify` so that property names in `.cjs`, `.js`, and `.ts` theme files only have quotations when necessary.

`theme.js` with `JSON.stringify`:

![Screenshot 2023-03-25 at 09 58 38](https://user-images.githubusercontent.com/26049962/227731481-c9f9447d-a118-4c2d-9c5c-dd78cfb1b5bd.png)

`theme.js` with `JSON5.stringify`:

![Screenshot 2023-03-25 at 09 59 47](https://user-images.githubusercontent.com/26049962/227731502-31c352ef-a962-4f08-81cd-20e4191b9162.png)
