### PR TITLE
feat: Straight to Color Picker on web during onboarding.

### DIFF
--- a/packages/core/src/components/Onboarding/index.tsx
+++ b/packages/core/src/components/Onboarding/index.tsx
@@ -34,7 +34,7 @@ export function Onboarding({
   const [palette, setPalette] = useState<TColorData[]>([])
   const [fileTypes, setFileTypes] = useState<TExportFileType[]>(defaultFiles)
 
-  const [page, setPage] = useState<number>(0)
+  const [page, setPage] = useState<number>(platform === 'web' ? 1 : 0)
 
   const handleExport = async (
     primaryColorHex: string,
@@ -60,13 +60,25 @@ export function Onboarding({
     })
   }
 
-  let content = (
-    <Welcome
-      onFinishOnboarding={onFinishOnboarding}
-      onUpdatePage={setPage}
-      platform={platform}
-    />
-  )
+  let content
+  if (platform === 'package') {
+    content = (
+      <Welcome
+        onFinishOnboarding={onFinishOnboarding}
+        onUpdatePage={setPage}
+        platform={platform}
+      />
+    )
+  } else {
+    content = (
+      <PickPrimary
+        initialPrimary={primaryColor}
+        onUpdatePage={setPage}
+        onUpdatePrimaryColor={(newColor: string) => setPrimaryColor(newColor)}
+        platform={platform}
+      />
+    )
+  }
 
   if (page === 1) {
     content = (

--- a/packages/core/src/components/Onboarding/pages/Referral.tsx
+++ b/packages/core/src/components/Onboarding/pages/Referral.tsx
@@ -33,6 +33,7 @@ export function Referral({
   const [isFriendChecked, setIsFriendChecked] = useState<boolean>(false)
   const [isGithubChecked, setIsGithubChecked] = useState<boolean>(false)
   const [isOtherChecked, setIsOtherChecked] = useState<boolean>(false)
+  const [isHackerNewsChecked, setIsHackerNewsChecked] = useState<boolean>(false)
 
   const shades = generateDefaultColorShades(primaryColor)
 
@@ -127,6 +128,10 @@ export function Referral({
                 posthog.capture('onboarding-referral-youtube')
               }
 
+              if (isHackerNewsChecked) {
+                posthog.capture('onboarding-referral-hackernews')
+              }
+
               onFinish()
             }}
           >
@@ -173,7 +178,7 @@ export function Referral({
             isChecked={isBlogChecked}
             onChange={(e) => setIsBlogChecked(e.target.checked)}
           >
-            Blog
+            Mirrorful Blog
           </Checkbox>
           <Checkbox
             isChecked={isTikTokChecked}
@@ -186,6 +191,12 @@ export function Referral({
             onChange={(e) => setIsGithubChecked(e.target.checked)}
           >
             Github
+          </Checkbox>
+          <Checkbox
+            isChecked={isHackerNewsChecked}
+            onChange={(e) => setIsHackerNewsChecked(e.target.checked)}
+          >
+            HackerNews
           </Checkbox>
           <Checkbox
             isChecked={isFriendChecked}

--- a/packages/mirrorful/editor/yarn.lock
+++ b/packages/mirrorful/editor/yarn.lock
@@ -1259,10 +1259,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@mirrorful/core@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@mirrorful/core/-/core-1.0.6.tgz#0285061d62844095ee0c2dca3c25726bacd059a5"
-  integrity sha512-nn9Kgf4BY4xj2qpR7dp4n/kVuQAB93BNGG1R4u5gfj1v9s3hIHImu80Zh1pn1Msc3iu+1Iy4mUzHwoRfzD4v0Q==
+"@mirrorful/core@1.0.9":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@mirrorful/core/-/core-1.0.9.tgz#8fec9d35612fc74e8cf4c66b67fa87e57c675f22"
+  integrity sha512-L9cY3BEU0+IojOQ7W1+NLdUdvFrQkGDItT1Dc0bXUFWxzoIgtM8kXcGQ3CfgA3ydHMkOFqAWT+i8ZOdGVQIxpw==
   dependencies:
     "@chakra-ui/icons" "^2.0.17"
     "@chakra-ui/react" "^2.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1073,27 +1073,6 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@mirrorful/core@1.0.6":
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/@mirrorful/core/-/core-1.0.6.tgz#0285061d62844095ee0c2dca3c25726bacd059a5"
-  integrity sha512-nn9Kgf4BY4xj2qpR7dp4n/kVuQAB93BNGG1R4u5gfj1v9s3hIHImu80Zh1pn1Msc3iu+1Iy4mUzHwoRfzD4v0Q==
-  dependencies:
-    "@chakra-ui/icons" "^2.0.17"
-    "@chakra-ui/react" "^2.5.2"
-    "@emotion/react" "^11.10.6"
-    "@emotion/styled" "^11.10.6"
-    "@hello-pangea/color-picker" "^3.2.2"
-    framer-motion "^10.6.0"
-    json5 "^2.2.3"
-    lottie-react "^2.4.0"
-    posthog-js "^1.51.3"
-    react "^18.2.0"
-    react-dom "^18.2.0"
-    react-highlight "^0.15.0"
-    react-icons "^4.8.0"
-    tinycolor2 "^1.6.0"
-    typescript "^4.9.5"
-
 "@mirrorful/eslint-config@file:packages/eslint-config":
   version "1.0.0"
 


### PR DESCRIPTION
We got some user feedback that on web no one is importing their theme, so we should just jump straight to the pick a color page. Also add Hackernews referral checkbox.