### PR TITLE
feat: added desired text-overflow behavior

### DIFF
--- a/packages/core/src/components/Shadows/ShadowsSection.tsx
+++ b/packages/core/src/components/Shadows/ShadowsSection.tsx
@@ -91,9 +91,19 @@ export function ShadowRow({
               display: 'flex',
               justifyContent: 'center',
               alignItems: 'center',
+              overflow: 'hidden',
+              whiteSpace: 'nowrap',
             }}
           >
-            <Text css={{ fontWeight: 'bold' }}>{shadowData.name}</Text>
+            <Text
+              css={{
+                fontWeight: 'bold',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {shadowData.name}
+            </Text>
           </Box>
           <Box>
             <Tooltip

--- a/packages/core/src/components/Typography/FontSizeRow.tsx
+++ b/packages/core/src/components/Typography/FontSizeRow.tsx
@@ -66,9 +66,19 @@ export function FontSizeRow({
             display: 'flex',
             justifyContent: 'center',
             alignItems: 'center',
+            overflow: 'hidden',
+            whiteSpace: 'nowrap',
           }}
         >
-          <Text css={{ fontWeight: 'bold' }}>{fontSizeData.name}</Text>
+          <Text
+            css={{
+              fontWeight: 'bold',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {fontSizeData.name}
+          </Text>
         </Box>
         <Box>
           <Text css={{ fontWeight: 'bold', width: 100 }} fontSize={18}>


### PR DESCRIPTION
fontsizes page and shadows page.
(ShadowSection.tsx and FontsizeRow.tsx)

long names should not wrap, instead, they should be truncated with ellipsis.

Closes #271 