### PR TITLE
Issue #275 docs-modification

### DIFF
--- a/docs/home/export-formats/colors.mdx
+++ b/docs/home/export-formats/colors.mdx
@@ -5,9 +5,9 @@ description: 'After configuring your theme in the editor, you can export colors 
 
 We currently export to the following file types: `.js`, `.ts`, `.css`, `.scss`, `.json`. If you're using tailwind, we also export to common js to work nicely with your tailwind config.
 
-## Using CSS
+<CodeGroup>
 
-```css
+```css CSS
 .primary-button {
   background-color: var(--color-primary);
 }
@@ -17,9 +17,7 @@ We currently export to the following file types: `.js`, `.ts`, `.css`, `.scss`, 
 <button style={{ backgroundColor: 'var(--color-primary)'}}>
 ```
 
-## Using SCSS
-
-```scss
+```scss SCSS
 /* Exact path will depend on your file structure */
 import './.mirrorful/theme.scss' 
 /* You can use the variables anywhere */
@@ -28,18 +26,14 @@ import './.mirrorful/theme.scss'
 }
 ```
 
-## Using Javascript / Typescript
-
-```javascript
+```javascript Javascript / Typescript
 /* Exact path will depend on your file structure */
 import { Tokens } from './mirrorful.js'
 
 <button backgroundColor={{ Tokens.primary.base }}>Click here</button>
 ```
 
-## Tailwind
-
-```javascript
+```javascript Tailwind
 const mirrorful = require('./.mirrorful/theme_cjs.js')
 
 theme: {
@@ -48,3 +42,4 @@ theme: {
   }
 }
 ```
+</CodeGroup>

--- a/docs/home/export-formats/font-sizes.mdx
+++ b/docs/home/export-formats/font-sizes.mdx
@@ -5,9 +5,9 @@ description: 'After configuring your theme in the editor, you can export font si
 
 We currently export to the following file types: `.js`, `.ts`, `.css`, `.scss`, `.json`. If you're using tailwind, we also export to common js to work nicely with your tailwind config.
 
-## Using CSS
+<CodeGroup>
 
-```css
+```css CSS
 .headings {
   font-size: var(--font-size-lg);
 }
@@ -17,9 +17,7 @@ We currently export to the following file types: `.js`, `.ts`, `.css`, `.scss`, 
 <button style={{ fontSize: 'var(--font-size-sm)' }}>
 ```
 
-## Using SCSS
-
-```scss
+```scss SCSS
 /* Exact path will depend on your file structure */
 import './.mirrorful/theme.scss';
 /* You can use the variables anywhere */
@@ -28,18 +26,14 @@ import './.mirrorful/theme.scss';
 }
 ```
 
-## Using Javascript / Typescript
-
-```javascript
+```javascript Javascript / Typescript
 /* Exact path will depend on your file structure */
 import { Tokens } from './mirrorful.js'
 
 <button fontSize={{ Tokens.fontSizes.sm }}>Click here</button>
 ```
 
-## Tailwind
-
-```javascript
+```javascript Tailwind
 const mirrorful = require('./.mirrorful/theme_cjs.js')
 
 theme: {
@@ -48,3 +42,4 @@ theme: {
   }
 }
 ```
+</CodeGroup>

--- a/docs/home/export-formats/shadows.mdx
+++ b/docs/home/export-formats/shadows.mdx
@@ -5,21 +5,19 @@ description: 'After configuring your theme in the editor, you can export shadows
 
 We currently export to the following file types: `.js`, `.ts`, `.css`, `.scss`, `.json`. If you're using tailwind, we also export to common js to work nicely with your tailwind config.
 
-## Using CSS
+<CodeGroup>
 
-```css
+```css CSS
 .headings {
   box-shadow: var(--box-shadows-sm);
 }
 ```
 
-```javascript
+```javascript 
 <button style={{ boxShadow: 'var(--box-shadows-sm)' }}>
 ```
 
-## Using SCSS
-
-```scss
+```scss SCSS
 /* Exact path will depend on your file structure */
 import './.mirrorful/theme.scss';
 /* You can use the variables anywhere */
@@ -28,18 +26,14 @@ import './.mirrorful/theme.scss';
 }
 ```
 
-## Using Javascript / Typescript
-
-```javascript
+```javascript Javascript / Typescript
 /* Exact path will depend on your file structure */
 import { Tokens } from './mirrorful.js'
 
 <button boxShadow={{ Tokens.boxShadows.sm }}>Click here</button>
 ```
 
-## Tailwind
-
-```javascript
+```javascript Tailwind
 const mirrorful = require('./.mirrorful/theme_cjs.js')
 
 theme: {
@@ -48,3 +42,4 @@ theme: {
   }
 }
 ```
+</CodeGroup>


### PR DESCRIPTION
Use `<CodeGroup>` Mintifly component to clean up SCSS vs CSS vs Tailwind vs JS on the export formats sections .
_kindly review it and I will be update this accordingly_ 