### PR TITLE
adjust current shadow input UI

### DIFF
--- a/packages/core/src/components/Shadows/EditShadowModal.tsx
+++ b/packages/core/src/components/Shadows/EditShadowModal.tsx
@@ -16,7 +16,8 @@ import {
 import { useDisclosure } from '@chakra-ui/react'
 import { AlertDialogDelete } from '@core/components/AlertDialogDelete'
 import { TShadowData } from '@core/types'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
+import { RgbColor } from '@hello-pangea/color-picker'
 
 import { ShadowColorPicker } from './ShadowColorPicker'
 
@@ -78,6 +79,33 @@ export function EditShadowModal({
     onClose()
   }
 
+  const [color, setColor] = useState(presetColor)
+
+  const [hOffset, sethOffset] = useState(initialValues?.hOffset ?? 0)
+  const [vOffset, setVOffset] = useState(initialValues?.vOffset ?? 0)
+  const [blur, setBlur] = useState(initialValues?.blur ?? 0)
+  const [spread, setSpread] = useState(initialValues?.spread ?? 0)
+
+  const codeResult = useMemo(() => {
+    return `${hOffset}px ${vOffset}px ${blur}px ${spread}px ${color}`
+  }, [hOffset, vOffset, blur, spread, color])
+
+  const handleColor = (color: RgbColor) => {
+    const rgba = `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`
+    setColor(rgba)
+  }
+
+  const formatColor = (input: string) => {
+    console.log(input)
+  }
+
+  useEffect(() => {
+    setVariant({
+      ...variant,
+      value: codeResult,
+    })
+  }, [codeResult])
+
   useEffect(() => {
     if (!isOpen) {
       setVariant(initialShadowVariant ?? { name: '', value: '' })
@@ -101,7 +129,9 @@ export function EditShadowModal({
           >
             <Box css={{ display: 'flex', flexDirection: 'column' }}>
               <FormControl>
-                <FormLabel>Variant Name</FormLabel>
+                <FormLabel css={{ fontSize: '0.75rem' }}>
+                  Variant name
+                </FormLabel>
                 <Input
                   value={variant.name}
                   onChange={(e) =>
@@ -109,20 +139,56 @@ export function EditShadowModal({
                   }
                 />
               </FormControl>
-              <FormControl css={{ marginTop: '32px' }}>
-                <FormLabel>Variant Value</FormLabel>
-                <Input
-                  value={variant.value}
-                  onChange={(e) =>
-                    setVariant({ ...variant, value: e.target.value })
-                  }
-                />
+              <FormControl>
+                <Box css={{ display: 'flex', marginTop: '1rem' }}>
+                  <Box css={{ width: '100%' }}>
+                    <FormLabel css={{ fontSize: '0.75rem' }}>
+                      Horizontal
+                    </FormLabel>
+                    <Input
+                      value={hOffset}
+                      onChange={(e) => sethOffset(Number(e.target.value))}
+                    />
+                  </Box>
+                  <Box css={{ width: '100%' }}>
+                    <FormLabel css={{ fontSize: '0.75rem' }}>
+                      Vertical
+                    </FormLabel>
+                    <Input
+                      value={vOffset}
+                      onChange={(e) => setVOffset(Number(e.target.value))}
+                    />
+                  </Box>
+                </Box>
+                <Box css={{ display: 'flex', marginTop: '1rem' }}>
+                  <Box css={{ width: '100%' }}>
+                    <FormLabel css={{ fontSize: '0.75rem' }}>Blur</FormLabel>
+                    <Input
+                      value={blur}
+                      onChange={(e) => setBlur(Number(e.target.value))}
+                    />
+                  </Box>
+                  <Box css={{ width: '100%' }}>
+                    <FormLabel css={{ fontSize: '0.75rem' }}>Spread</FormLabel>
+                    <Input
+                      value={spread}
+                      onChange={(e) => setSpread(Number(e.target.value))}
+                    />
+                  </Box>
+                </Box>
               </FormControl>
               <ShadowColorPicker
-                variant={variant}
-                setVariant={setVariant}
+                blur={blur}
+                spread={spread}
+                hOffset={hOffset}
+                vOffset={vOffset}
+                setBlur={setBlur}
+                setSpread={setSpread}
+                sethOffset={sethOffset}
+                setVOffset={setVOffset}
+                codeResult={codeResult}
+                handleColor={handleColor}
                 presetColor={presetColor}
-                initialValues={initialValues}
               />
 
               <Box

--- a/packages/core/src/components/Shadows/EditShadowModal.tsx
+++ b/packages/core/src/components/Shadows/EditShadowModal.tsx
@@ -18,6 +18,7 @@ import { AlertDialogDelete } from '@core/components/AlertDialogDelete'
 import { TShadowData } from '@core/types'
 import { RgbColor } from '@hello-pangea/color-picker'
 import { useEffect, useMemo, useState } from 'react'
+
 import { ShadowColorPicker } from './ShadowColorPicker'
 
 export function EditShadowModal({

--- a/packages/core/src/components/Shadows/EditShadowModal.tsx
+++ b/packages/core/src/components/Shadows/EditShadowModal.tsx
@@ -12,12 +12,12 @@ import {
   ModalHeader,
   ModalOverlay,
   Text,
+  useDisclosure,
 } from '@chakra-ui/react'
-import { useDisclosure } from '@chakra-ui/react'
 import { AlertDialogDelete } from '@core/components/AlertDialogDelete'
 import { TShadowData } from '@core/types'
-import { useEffect, useState, useMemo } from 'react'
 import { RgbColor } from '@hello-pangea/color-picker'
+import { useEffect, useMemo, useState } from 'react'
 
 import { ShadowColorPicker } from './ShadowColorPicker'
 
@@ -93,10 +93,6 @@ export function EditShadowModal({
   const handleColor = (color: RgbColor) => {
     const rgba = `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`
     setColor(rgba)
-  }
-
-  const formatColor = (input: string) => {
-    console.log(input)
   }
 
   useEffect(() => {

--- a/packages/core/src/components/Shadows/EditShadowModal.tsx
+++ b/packages/core/src/components/Shadows/EditShadowModal.tsx
@@ -18,7 +18,6 @@ import { AlertDialogDelete } from '@core/components/AlertDialogDelete'
 import { TShadowData } from '@core/types'
 import { RgbColor } from '@hello-pangea/color-picker'
 import { useEffect, useMemo, useState } from 'react'
-
 import { ShadowColorPicker } from './ShadowColorPicker'
 
 export function EditShadowModal({
@@ -80,7 +79,7 @@ export function EditShadowModal({
   }
 
   const [color, setColor] = useState(presetColor)
-
+  const [inputColor, setInputColor] = useState(presetColor)
   const [hOffset, sethOffset] = useState(initialValues?.hOffset ?? 0)
   const [vOffset, setVOffset] = useState(initialValues?.vOffset ?? 0)
   const [blur, setBlur] = useState(initialValues?.blur ?? 0)
@@ -93,6 +92,30 @@ export function EditShadowModal({
   const handleColor = (color: RgbColor) => {
     const rgba = `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`
     setColor(rgba)
+  }
+
+  const formatColor = (input: string) => {
+    if (
+      /^rgba?\(\s*\d+\s*,\s*\d+\s*,\s*\d+\s*(,\s*(0\.\d+|\d+(\.\d+)?))?\s*\)$/i.test(
+        input
+      )
+    ) {
+      const colors = input
+        .split('rgba')[1]
+        .replace('(', '')
+        .replace(')', '')
+        .split(',')
+        .map((value) => Number(value))
+      handleColor({
+        r: colors[0],
+        g: colors[1],
+        b: colors[2],
+        a: colors[3],
+      })
+    } else {
+      setError('Invalid color')
+    }
+    setInputColor(input)
   }
 
   useEffect(() => {
@@ -172,6 +195,13 @@ export function EditShadowModal({
                     />
                   </Box>
                 </Box>
+                <Box css={{ marginTop: '1rem' }}>
+                  <FormLabel css={{ fontSize: '0.75rem' }}>RGBA</FormLabel>
+                  <Input
+                    value={inputColor}
+                    onChange={(e) => formatColor(e.target.value)}
+                  />
+                </Box>
               </FormControl>
               <ShadowColorPicker
                 blur={blur}
@@ -184,7 +214,7 @@ export function EditShadowModal({
                 setVOffset={setVOffset}
                 codeResult={codeResult}
                 handleColor={handleColor}
-                presetColor={presetColor}
+                color={color}
               />
 
               <Box

--- a/packages/core/src/components/Shadows/EditShadowModal.tsx
+++ b/packages/core/src/components/Shadows/EditShadowModal.tsx
@@ -113,6 +113,7 @@ export function EditShadowModal({
         b: colors[2],
         a: colors[3],
       })
+      setError(null)
     } else {
       setError('Invalid color')
     }

--- a/packages/core/src/components/Shadows/EditShadowModal.tsx
+++ b/packages/core/src/components/Shadows/EditShadowModal.tsx
@@ -86,9 +86,7 @@ export function EditShadowModal({
   const [blur, setBlur] = useState(initialValues?.blur ?? 0)
   const [spread, setSpread] = useState(initialValues?.spread ?? 0)
 
-  const codeResult = useMemo(() => {
-    return `${hOffset}px ${vOffset}px ${blur}px ${spread}px ${color}`
-  }, [hOffset, vOffset, blur, spread, color])
+  const codeResult = `${hOffset}px ${vOffset}px ${blur}px ${spread}px ${color}`
 
   const handleColor = (color: RgbColor) => {
     const rgba = `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`

--- a/packages/core/src/components/Shadows/ShadowColorPicker.tsx
+++ b/packages/core/src/components/Shadows/ShadowColorPicker.tsx
@@ -21,7 +21,7 @@ export function ShadowColorPicker({
   setVOffset,
   codeResult,
   handleColor,
-  presetColor,
+  color,
 }: {
   blur: number
   spread: number
@@ -33,7 +33,7 @@ export function ShadowColorPicker({
   setVOffset: Dispatch<SetStateAction<number>>
   codeResult: string
   handleColor: (rgb: RgbColor) => void
-  presetColor: string
+  color: string
 }) {
   return (
     <Box
@@ -48,7 +48,7 @@ export function ShadowColorPicker({
       <Flex justifyContent={'space-between'} mt="1em">
         <SketchPicker
           width="45%"
-          color={presetColor}
+          color={color}
           onChange={(e) => handleColor(e.rgb)}
         />
         <Box

--- a/packages/core/src/components/Shadows/ShadowColorPicker.tsx
+++ b/packages/core/src/components/Shadows/ShadowColorPicker.tsx
@@ -7,59 +7,34 @@ import {
   SliderTrack,
   Text,
 } from '@chakra-ui/react'
-import { TShadowData } from '@core/types'
 import { RgbColor, SketchPicker } from '@hello-pangea/color-picker'
-import React, { useEffect, useState } from 'react'
+import { Dispatch, SetStateAction } from 'react'
 
 export function ShadowColorPicker({
-  variant,
-  setVariant,
+  blur,
+  spread,
+  hOffset,
+  vOffset,
+  setBlur,
+  setSpread,
+  sethOffset,
+  setVOffset,
+  codeResult,
+  handleColor,
   presetColor,
-  initialValues = {
-    hOffset: 0,
-    vOffset: 0,
-    blur: 0,
-    spread: 0,
-  },
 }: {
-  setVariant: React.Dispatch<React.SetStateAction<TShadowData>>
-  variant: {
-    name: string
-    value: string
-  }
+  blur: number
+  spread: number
+  hOffset: number
+  vOffset: number
+  setBlur: Dispatch<SetStateAction<number>>
+  setSpread: Dispatch<SetStateAction<number>>
+  sethOffset: Dispatch<SetStateAction<number>>
+  setVOffset: Dispatch<SetStateAction<number>>
+  codeResult: string
+  handleColor: (rgb: RgbColor) => void
   presetColor: string
-  initialValues?:
-    | {
-        hOffset: number
-        vOffset: number
-        blur: number
-        spread: number
-      }
-    | undefined
 }) {
-  const [color, setColor] = useState(
-    presetColor ? presetColor : 'rgba(1, 1, 1, 0.4)'
-  )
-
-  const [hOffset, sethOffset] = useState(initialValues.hOffset)
-  const [vOffset, setVOffset] = useState(initialValues.vOffset)
-  const [blur, setBlur] = useState(initialValues.blur)
-  const [spread, setSpread] = useState(initialValues.spread)
-
-  const codeResult = ` ${hOffset}px ${vOffset}px ${blur}px ${spread}px ${color}`
-
-  const handleColor = (color: RgbColor) => {
-    const rgba = `rgba(${color.r}, ${color.g}, ${color.b}, ${color.a})`
-    setColor(rgba)
-  }
-
-  useEffect(() => {
-    setVariant({
-      ...variant,
-      value: codeResult,
-    })
-  }, [codeResult, color, vOffset, hOffset, blur, spread])
-
   return (
     <Box
       sx={{
@@ -93,7 +68,7 @@ export function ShadowColorPicker({
               min={-25}
               max={25}
               defaultValue={hOffset}
-              onChangeEnd={(val) => sethOffset(val)}
+              onChange={(val) => sethOffset(val)}
             >
               <SliderTrack>
                 <SliderFilledTrack />
@@ -106,7 +81,7 @@ export function ShadowColorPicker({
               min={-25}
               max={25}
               defaultValue={vOffset}
-              onChangeEnd={(val) => setVOffset(val)}
+              onChange={(val) => setVOffset(val)}
             >
               <SliderTrack>
                 <SliderFilledTrack />
@@ -117,7 +92,7 @@ export function ShadowColorPicker({
             <Slider
               aria-label="slider-blur"
               defaultValue={blur}
-              onChangeEnd={(val) => setBlur(val)}
+              onChange={(val) => setBlur(val)}
             >
               <SliderTrack>
                 <SliderFilledTrack />
@@ -128,7 +103,7 @@ export function ShadowColorPicker({
             <Slider
               aria-label="slider-Spread"
               defaultValue={spread}
-              onChangeEnd={(val) => setSpread(val)}
+              onChange={(val) => setSpread(val)}
               size="lg"
             >
               <SliderTrack>


### PR DESCRIPTION
resolves #257

# Notes

- Changed `onChangeEnd` to `onChange` I prefer to visually see the change that I make as I'm changing the values instead of having to wait until I drop the picker to view the change. Let me know if there's a thought process behind having `onChangeEnd`
- Wrapped `codeResult` into a `useMemo` hook to prevent unnecessary re-renders and recalculations
- Uplifting all state from `ShadowColorPicker` to `EditShadowModal` to allow both components to consume the necessary state variables
- Split the input field to multiple fields that handles their own individual value


# Sidenote
There's a lot of prop drilling in the current codebase. I know that there were some discussion around using zustand. I hope to start moving towards a state management solution as mirrorful grows :rocket: