### PR TITLE
improv: wrap onboarding steps in form elements and make them keyboard accessible

### DIFF
--- a/packages/core/src/components/Onboarding/pages/ExportSettings.tsx
+++ b/packages/core/src/components/Onboarding/pages/ExportSettings.tsx
@@ -35,7 +35,7 @@ export function ExportSettings({
   const shades = generateDefaultColorShades(primaryColor)
 
   return (
-    <Box css={{ display: 'flex', height: '100%' }}>
+    <Box css={{ display: 'flex', height: '100%' }} as="form">
       <Box
         width="50%"
         padding="12px"
@@ -80,11 +80,14 @@ export function ExportSettings({
             padding="8px 36px"
             size="lg"
             rightIcon={<ArrowForwardIcon />}
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault()
               onExport()
               onUpdatePage(6)
             }}
             isDisabled={!fileTypes.length}
+            type="submit"
+            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/ExportSettings.tsx
+++ b/packages/core/src/components/Onboarding/pages/ExportSettings.tsx
@@ -87,7 +87,6 @@ export function ExportSettings({
             }}
             isDisabled={!fileTypes.length}
             type="submit"
-            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/ImportInstructions.tsx
+++ b/packages/core/src/components/Onboarding/pages/ImportInstructions.tsx
@@ -33,7 +33,7 @@ export function ImportInstructions({
   const shades = generateDefaultColorShades(primaryColor)
 
   return (
-    <Box css={{ display: 'flex', height: '100%', flexGrow: 1 }}>
+    <Box css={{ display: 'flex', height: '100%', flexGrow: 1 }} as="form">
       <Box
         css={{
           padding: '12px',
@@ -89,9 +89,12 @@ export function ImportInstructions({
             padding={'8px 36px'}
             size="lg"
             rightIcon={<ArrowForwardIcon />}
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault()
               onUpdatePage(7)
             }}
+            type="submit"
+            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/ImportInstructions.tsx
+++ b/packages/core/src/components/Onboarding/pages/ImportInstructions.tsx
@@ -94,7 +94,6 @@ export function ImportInstructions({
               onUpdatePage(7)
             }}
             type="submit"
-            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/NamePrimary.tsx
+++ b/packages/core/src/components/Onboarding/pages/NamePrimary.tsx
@@ -95,7 +95,6 @@ export function NamePrimary({
               onUpdatePage(3)
             }}
             type="submit"
-            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/NamePrimary.tsx
+++ b/packages/core/src/components/Onboarding/pages/NamePrimary.tsx
@@ -26,7 +26,7 @@ export function NamePrimary({
   const shades = generateDefaultColorShades(primaryColor)
 
   return (
-    <Box css={{ display: 'flex', height: '100%' }}>
+    <Box css={{ display: 'flex', height: '100%' }} as="form">
       <Box
         css={{
           width: '50%',
@@ -84,7 +84,8 @@ export function NamePrimary({
             padding={'8px 36px'}
             size="lg"
             rightIcon={<ArrowForwardIcon />}
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault()
               if (!name) {
                 setError('Please enter a name for your color.')
                 return
@@ -93,6 +94,8 @@ export function NamePrimary({
               onUpdatePrimaryName(name)
               onUpdatePage(3)
             }}
+            type="submit"
+            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/OtherColors.tsx
+++ b/packages/core/src/components/Onboarding/pages/OtherColors.tsx
@@ -109,7 +109,6 @@ export function OtherColors({
               }
             }}
             type="submit"
-            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/OtherColors.tsx
+++ b/packages/core/src/components/Onboarding/pages/OtherColors.tsx
@@ -41,7 +41,7 @@ export function OtherColors({
   }, [palette, handleGeneratePalette])
 
   return (
-    <Box css={{ display: 'flex', height: '100%' }}>
+    <Box css={{ display: 'flex', height: '100%' }} as="form">
       <Box
         css={{
           width: '50%',
@@ -98,7 +98,8 @@ export function OtherColors({
             padding={'8px 36px'}
             size="lg"
             rightIcon={<ArrowForwardIcon />}
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault()
               onUpdatePalette(palette)
 
               if (platform === 'web') {
@@ -107,6 +108,8 @@ export function OtherColors({
                 onUpdatePage(5)
               }
             }}
+            type="submit"
+            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/PickPrimary.tsx
+++ b/packages/core/src/components/Onboarding/pages/PickPrimary.tsx
@@ -75,7 +75,6 @@ export function PickPrimary({
               onUpdatePage(2)
             }}
             type="submit"
-            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/PickPrimary.tsx
+++ b/packages/core/src/components/Onboarding/pages/PickPrimary.tsx
@@ -21,7 +21,7 @@ export function PickPrimary({
   const shades = generateDefaultColorShades(primaryColor)
 
   return (
-    <Box css={{ display: 'flex', height: '100%' }}>
+    <Box css={{ display: 'flex', height: '100%' }} as="form">
       <Box
         css={{
           width: '50%',
@@ -69,10 +69,13 @@ export function PickPrimary({
             padding={'8px 36px'}
             size="lg"
             rightIcon={<ArrowForwardIcon />}
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault()
               onUpdatePrimaryColor(primaryColor)
               onUpdatePage(2)
             }}
+            type="submit"
+            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/Referral.tsx
+++ b/packages/core/src/components/Onboarding/pages/Referral.tsx
@@ -30,7 +30,7 @@ export function Referral({
   const shades = generateDefaultColorShades(primaryColor)
 
   return (
-    <Box css={{ display: 'flex', height: '100%' }}>
+    <Box css={{ display: 'flex', height: '100%' }} as="form">
       <Box
         css={{
           width: '50%',
@@ -126,6 +126,8 @@ export function Referral({
 
               onFinish()
             }}
+            type="submit"
+            autoFocus
           >
             Finish
           </Button>

--- a/packages/core/src/components/Onboarding/pages/Referral.tsx
+++ b/packages/core/src/components/Onboarding/pages/Referral.tsx
@@ -127,7 +127,6 @@ export function Referral({
               onFinish()
             }}
             type="submit"
-            autoFocus
           >
             Finish
           </Button>

--- a/packages/core/src/components/Onboarding/pages/ReviewPrimary.tsx
+++ b/packages/core/src/components/Onboarding/pages/ReviewPrimary.tsx
@@ -34,7 +34,7 @@ export function ReviewPrimary({
   const shades = generateDefaultColorShades(primaryColor)
 
   return (
-    <Box css={{ display: 'flex', height: '100%' }}>
+    <Box css={{ display: 'flex', height: '100%' }} as="form">
       <Box
         css={{
           width: '50%',
@@ -94,9 +94,12 @@ export function ReviewPrimary({
             padding={'8px 36px'}
             size="lg"
             rightIcon={<ArrowForwardIcon />}
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault()
               onUpdatePage(4)
             }}
+            type="submit"
+            autoFocus
           >
             Next
           </Button>

--- a/packages/core/src/components/Onboarding/pages/ReviewPrimary.tsx
+++ b/packages/core/src/components/Onboarding/pages/ReviewPrimary.tsx
@@ -99,7 +99,6 @@ export function ReviewPrimary({
               onUpdatePage(4)
             }}
             type="submit"
-            autoFocus
           >
             Next
           </Button>


### PR DESCRIPTION
Previously, the onboarding was not keyboard accessible - Pressing enter did not move to the next step. This commit wraps the onboarding steps in a form component and changes the button to a submit so that the whole flow is `enter`-accessible. Also to prevent default form submit behaviour, we also need to add e.preventDefault() on the button clicks

Fixes #267

