### PR TITLE
quick fix: add dash in color names : toTailwind.ts

### DIFF
--- a/packages/core/src/translators/toTailwind.ts
+++ b/packages/core/src/translators/toTailwind.ts
@@ -10,7 +10,7 @@ export const toTailwind = ({
 
   if (colorData) {
     theme.colors = colorData.reduce<Record<string, any>>((acc, color) => {
-      acc[color.name.toLowerCase()] = {
+      acc[color.name.toLowerCase().trim().replace(' ', '-')] = {
         ...color.variants,
         DEFAULT: color.baseColor,
       }


### PR DESCRIPTION
When generating tailwind theme to export, color names weren't properly named.

Issue: 
![image](https://user-images.githubusercontent.com/27858990/231247477-0b20ba53-3af0-43d7-b9f1-40fff9c71a32.png)

fix:
![image](https://user-images.githubusercontent.com/27858990/231247512-0c4b7f18-2580-45f1-a4f2-778929a6a01c.png)
