### PR TITLE
cannot have two variants with the same name (#306)

### DIFF
--- a/packages/core/src/components/ColorPalette/ColorDisplay.tsx
+++ b/packages/core/src/components/ColorPalette/ColorDisplay.tsx
@@ -333,6 +333,10 @@ export function ColorDisplay({
         isOpen={isAddVariantModalOpen}
         onClose={onAddVariantModalClose}
         onUpdateVariant={(newVariant: TNamedToken) => {
+          // check if the new Variant name already exist, if exist throw error
+          if (newVariant.name in colorData) {
+            throw new Error('Variant Name Already Exist')
+          }
           const updatedColorData = { ...colorData }
           updatedColorData[newVariant.name] = newVariant.token
 

--- a/packages/core/src/components/ColorPalette/ColorDisplay.tsx
+++ b/packages/core/src/components/ColorPalette/ColorDisplay.tsx
@@ -335,7 +335,7 @@ export function ColorDisplay({
         onUpdateVariant={(newVariant: TNamedToken) => {
           // check if the new Variant name already exist, if exist throw error
           if (newVariant.name in colorData) {
-            throw new Error('Variant Name Already Exist')
+            throw new Error('This name already exists, please choose a different name.')
           }
           const updatedColorData = { ...colorData }
           updatedColorData[newVariant.name] = newVariant.token

--- a/packages/core/src/components/ColorPalette/ColorDisplay.tsx
+++ b/packages/core/src/components/ColorPalette/ColorDisplay.tsx
@@ -333,9 +333,10 @@ export function ColorDisplay({
         isOpen={isAddVariantModalOpen}
         onClose={onAddVariantModalClose}
         onUpdateVariant={(newVariant: TNamedToken) => {
-          // check if the new Variant name already exist, if exist throw error
           if (newVariant.name in colorData) {
-            throw new Error('This name already exists, please choose a different name.')
+            throw new Error(
+              'This name already exists, please choose a different name.'
+            )
           }
           const updatedColorData = { ...colorData }
           updatedColorData[newVariant.name] = newVariant.token

--- a/packages/core/src/components/ColorPalette/EditVariantModal.tsx
+++ b/packages/core/src/components/ColorPalette/EditVariantModal.tsx
@@ -74,7 +74,15 @@ export function EditVariantModal({
     }
     // Remove error so it doesn't persist...
     setError(null)
-    onUpdateVariant(variant)
+    // catch any thrown errors on save
+    try {
+      onUpdateVariant(variant)
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err.message)
+        return
+      }
+    }
     onClose()
   }
 


### PR DESCRIPTION
Fix #306 
- before saving a new variant check if this name already exists to not overwrite it, if exists throw an error
- catch any errors in `EditVariantModal` that happens with the save handler and set the already existing error state to the thrown error message 

here's an example
![image](https://user-images.githubusercontent.com/65990275/231610336-ce2fcd02-7234-44a8-b476-20dd86623894.png)
