### PR TITLE
chore: add paths property to github action workflows

### DIFF
--- a/.github/workflows/core.yml
+++ b/.github/workflows/core.yml
@@ -3,9 +3,13 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'packages/core/**'
   push:
     branches:
       - main
+    paths:
+      - 'packages/core/**'
 
 jobs:
   build:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -3,9 +3,15 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'packages/core/**'
+      - 'packages/mirrorful/**'
   push:
     branches:
       - main
+    paths:
+      - 'packages/core/**'
+      - 'packages/mirrorful/**'
 
 jobs:
   build:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -3,9 +3,13 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'packages/server/**'
   push:
     branches:
       - main
+    paths:
+      - 'packages/server/**'
 
 jobs:
   build:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - 'apps/web/**'
+      - 'packages/core/**'
   push:
     branches:
       - main

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -3,9 +3,13 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'apps/web/**'
   push:
     branches:
       - main
+    paths:
+      - 'apps/web/**'
 
 jobs:
   build:


### PR DESCRIPTION
This will ensure that only the workflows relevant to the changes will be triggered, instead of all workflows running.

Ref:
- https://stackoverflow.com/questions/63822219/how-to-run-github-actions-workflow-only-if-the-pushed-files-are-in-a-specific-fo
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths

Fixes #355 