### PR TITLE
Retain the order of colors when renaming

### DIFF
--- a/packages/core/src/components/ColorPalette/ColorPaletteSection.tsx
+++ b/packages/core/src/components/ColorPalette/ColorPaletteSection.tsx
@@ -70,9 +70,12 @@ export function ColorPaletteSection({
                 colorName={name}
                 colorData={colors[name] as TTokenGroup}
                 onUpdateColorName={(newName: string) => {
-                  const newColors = { ...colors }
-                  delete newColors[name]
-                  newColors[newName] = colors[name]
+                  // Rename the color while retaining the order of the keys
+                  const newColors = Object.keys(colors).reduce((acc, key) => {
+                    if (key !== name) acc[key] = colors[key]
+                    else acc[newName] = colors[key]
+                    return acc
+                  }, {} as TTokenGroup)
 
                   onUpdateColors(newColors)
                 }}


### PR DESCRIPTION
Should fix [#364](https://github.com/Mirrorful/mirrorful/issues/364) by retaining the order of colors in the `colors` object.