### PR TITLE
Update ESLint plugin docs for the NPM registry

### DIFF
--- a/packages/eslint-plugin/README.md
+++ b/packages/eslint-plugin/README.md
@@ -2,7 +2,7 @@
 
 This directory contains a plugin containing ESLint rules for Mirrorful. This plugin should only be installed into a pre-existing [Mirrorful](https://github.com/mirrorful/mirrorful) project.
 
-See it in action [here](/examples/tailwind-next/).
+See it in action [here](https://github.com/Mirrorful/mirrorful/tree/main/examples/eslint-demo).
 
 ## 📦 Installation
 
@@ -50,15 +50,15 @@ Alternatively, you can individually configure the rules you want to use under th
 
 <!-- begin auto-generated rules list -->
 
-| Name                                                     | Description                                           |
-| :------------------------------------------------------- | :---------------------------------------------------- |
-| [no-hardcoded-colors](docs/rules/no-hardcoded-colors.md) | Disallow hard-coded color values when using Mirrorful |
+| Name                                                                                                                        | Description                                           |
+| :-------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------- |
+| [no-hardcoded-colors](https://github.com/Mirrorful/mirrorful/blob/main/packages/eslint-plugin/rules/no-hardcoded-colors.md) | Disallow hard-coded color values when using Mirrorful |
 
 <!-- end auto-generated rules list -->
 
 ## 💻 Development and Publishing
 
-You can publish this plugin to the NPM registry:
+You can publish this plugin to the [NPM registry](https://www.npmjs.com/package/eslint-plugin-mirrorful):
 
 ```
 npm publish

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-mirrorful",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "ESLint rules for Mirrorful projects.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
NPM doesn't like relative links to a GitHub repo. Also linked directly to the NPM plugin page.