### PR TITLE
feat: allow the user to input hex values in color picker

### DIFF
--- a/packages/core/src/components/ColorPalette/ColorPicker.tsx
+++ b/packages/core/src/components/ColorPalette/ColorPicker.tsx
@@ -14,6 +14,7 @@ import tinycolor from 'tinycolor2'
 
 import HexPicker from './HexPicker'
 import RgbaPicker from './RgbaPicker'
+import { parseHexString } from './utils'
 
 const formats = ['HEX', 'RGBA'] as const
 type TFormat = 'HEX' | 'RGBA'
@@ -74,13 +75,20 @@ function DropdownInput({
       </Menu>
       {format === 'HEX' && (
         <Input
-          isDisabled={true}
           type="text"
           css={{ width: '100%', height: '100%', minHeight: '2.5rem' }}
           value={hexInputValue}
           onChange={(e) => {
             setHexInputValue(e.target.value)
-            onChange(e.target.value)
+          }}
+          onBlur={() => {
+            /* Since the user may not have entered a valid hexcolor string, we parse it to convert it to a valid hexcolor string */
+            const parsedHexString = parseHexString(
+              hexInputValue,
+              tinycolor(colorPickerColor).toHexString()
+            )
+            setHexInputValue(parsedHexString)
+            onChange(parsedHexString)
           }}
         />
       )}

--- a/packages/core/src/components/ColorPalette/utils.ts
+++ b/packages/core/src/components/ColorPalette/utils.ts
@@ -24,6 +24,44 @@ export const newShade = (hexColor: string, magnitude: number) => {
     return hexColor
   }
 }
+
+/* convert a text string to a valid hexcolor string. If no valid hexcolor string
+  is available, we return the fallback color */
+export const parseHexString = (hexString: string, fallback: string) => {
+  /* First if the string has a '#' at the start we remove it */
+  if (hexString[0] === '#') {
+    hexString = hexString.substring(1)
+  }
+
+  const hexStringLength = hexString.length
+  /* Then we convert the string to 6 characters by trimming or adding characters */
+  if (hexStringLength < 6) {
+    hexString += new Array(6 - hexStringLength).fill(0).join('')
+  }
+  hexString = hexString.substring(0, 6)
+
+  /* Now we check if the hexString has any non-hex characters, if it has we cannot parse it
+    and we return the fallback color */
+  if (!isHexString(hexString)) {
+    return fallback
+  }
+
+  /* Since the hex representation expects a '#' at the start, we add it back. This will also allow user
+    to input numbers without the hash prefix – we auto add the hash.
+  */
+  hexString = '#' + hexString
+
+  return hexString
+}
+
+const isHexString = (str: string) => {
+  const regexp = /^[0-9a-fA-F]+$/
+  if (regexp.test(str)) {
+    return true
+  }
+  return false
+}
+
 /* eslint-enable @typescript-eslint/no-unused-expressions */
 
 const scaleDiff = 7


### PR DESCRIPTION
We use the following logic to take care of invalid values - 
INVALID VALUE - revert back to last valid value
VALUE > 6 - trim to six characters
VALUE < 6 - Fill 0's to make it 6 characters

Fixes #405 