### PR TITLE
fix: reduced font weight allowed limits

### DIFF
--- a/packages/core/src/components/Typography/FontWeight/EditFontWeightModal.tsx
+++ b/packages/core/src/components/Typography/FontWeight/EditFontWeightModal.tsx
@@ -70,8 +70,8 @@ export function EditFontWeightModal({
       return
     }
 
-    if (Number(variant.token.value) < 1 || Number(variant.token.value) > 1000) {
-      setError('Font weight must be between 1 and 1000.')
+    if (Number(variant.token.value) < 1 || Number(variant.token.value) > 900) {
+      setError('Font weight must be between 1 and 900.')
       return
     }
 


### PR DESCRIPTION
Editing the font-weight above 900 or adding a similar weight would show error message. #416 
<img width="399" alt="image" src="https://github.com/Mirrorful/mirrorful/assets/28934258/d644f6c2-8d06-43fe-ae34-07500a3951e3">
