### PR TITLE
Deleted filter function on shadow modal 

### DIFF
--- a/packages/core/src/components/Shadows/EditShadowModal.tsx
+++ b/packages/core/src/components/Shadows/EditShadowModal.tsx
@@ -427,28 +427,26 @@ export function EditShadowModal({
               </Box>
               <FormControl>
                 <Box>
-                  {newInitialValues
-                    ?.filter(
-                      (_arg: ShadowValue, index: number) =>
-                        shadowIndex === index
-                    )
-                    .map((_arg: ShadowValue, index: number) => (
-                      <ShadowColorPicker
-                        key={index}
-                        blur={blur[index]}
-                        spread={spread[index]}
-                        hOffset={hOffset[index]}
-                        vOffset={vOffset[index]}
-                        handleColor={handleColor}
-                        handleBlur={handleBlur}
-                        handleSpread={handleSpread}
-                        handleHOffset={handleHOffset}
-                        handleVOffset={handleVOffset}
-                        color={color[index]}
-                        index={index}
-                        codeResult={codeResult}
-                      />
-                    ))}
+                  {newInitialValues?.map((_arg: ShadowValue, index: number) => (
+                    <Box key={index}>
+                      {shadowIndex === index && (
+                        <ShadowColorPicker
+                          blur={blur[index]}
+                          spread={spread[index]}
+                          hOffset={hOffset[index]}
+                          vOffset={vOffset[index]}
+                          handleColor={handleColor}
+                          handleBlur={handleBlur}
+                          handleSpread={handleSpread}
+                          handleHOffset={handleHOffset}
+                          handleVOffset={handleVOffset}
+                          color={color[index]}
+                          index={index}
+                          codeResult={codeResult}
+                        />
+                      )}
+                    </Box>
+                  ))}
                 </Box>
               </FormControl>
 


### PR DESCRIPTION
I noticed a bug when adding a new shadow, it won't update the values on the slides or input field. 
<img width="498" alt="Screen Shot 2023-05-17 at 5 10 50 PM" src="https://github.com/Mirrorful/mirrorful/assets/57118300/2099c6b6-a3d5-4ff8-a9f0-db6a66366fc6">
