### PR TITLE
Fix: toggle dark/light mode on mobile

### DIFF
--- a/packages/core/src/components/Sidebar/Sidebar.tsx
+++ b/packages/core/src/components/Sidebar/Sidebar.tsx
@@ -907,9 +907,6 @@ export function Sidebar({
                     flexDirection={isCollapsed ? 'column' : 'row'}
                     alignItems="center"
                     justifyContent="space-between"
-                    onClick={() => {
-                      toggleColorMode()
-                    }}
                   >
                     <Box
                       css={{
@@ -937,10 +934,10 @@ export function Sidebar({
                           <Switch
                             colorScheme="gray"
                             css={{ margin: '0 8px', cursor: 'pointer' }}
+                            isChecked={colorMode === 'light'}
                             onChange={() => {
                               toggleColorMode()
                             }}
-                            isChecked={colorMode === 'light'}
                           />
                           <Box
                             cursor={'pointer'}


### PR DESCRIPTION
This PR is the first pass for issue #486

Fixes the toggle dark/light mode on mobile.

Here's how it looks 


https://github.com/Mirrorful/mirrorful/assets/94234459/174d8a7a-1fcf-49b2-9b0b-b18114ecc09b

