### PR TITLE
🐛 fix: Complementary palette's opacity should match primary's opacity

### DIFF
--- a/packages/core/src/components/Onboarding/index.tsx
+++ b/packages/core/src/components/Onboarding/index.tsx
@@ -47,6 +47,7 @@ export function Onboarding({
   const authInfo = useAuthInfo()
   const [primaryColor, setPrimaryColor] = useState<AnyColor>('#9F7AEA')
   const [primaryName, setPrimaryName] = useState<string>('')
+  const [opacity, setOpacity] = useState<number>(1)
   const [palette, setPalette] = useState<TTokenGroup>({})
   const [fileTypes, setFileTypes] = useState<TExportFileType[]>(defaultFiles)
 
@@ -61,6 +62,8 @@ export function Onboarding({
 
     const hslColor = tinycolor(newColor).toHsl()
     const name = nameThatColor(hslColor)
+
+    setOpacity(hslColor.a)
     setPrimaryName(name)
   }
 
@@ -156,6 +159,7 @@ export function Onboarding({
         onUpdatePalette={(newPalette: TTokenGroup) => {
           Object.keys(newPalette).map((colorName) => {
             const color = newPalette[colorName]
+
             if (assertToken(color)) {
               newPalette[colorName] = {
                 DEFAULT: {
@@ -177,6 +181,7 @@ export function Onboarding({
         primaryName={primaryName}
         onUpdatePage={setPage}
         platform={platform}
+        opacity={opacity}
       />
     )
   } else if (page === 4) {

--- a/packages/core/src/components/Onboarding/pages/OtherColors.tsx
+++ b/packages/core/src/components/Onboarding/pages/OtherColors.tsx
@@ -16,6 +16,7 @@ export function OtherColors({
   primaryColor,
   primaryName,
   platform,
+  opacity,
 }: {
   initialPalette: TTokenGroup
   onUpdatePalette: (newPalette: TTokenGroup) => void
@@ -23,13 +24,18 @@ export function OtherColors({
   primaryColor: string
   primaryName: string
   platform: TPlatform
+  opacity: number
 }) {
   const [palette, setPalette] = useState<TTokenGroup>(initialPalette)
 
   const shades = generateDefaultColorShades({ primary: primaryColor })
 
   const handleGeneratePalette = useCallback(() => {
-    const alternativeColors = generatePalette(primaryColor, primaryName)
+    const alternativeColors = generatePalette(
+      primaryColor,
+      primaryName,
+      opacity
+    )
 
     setPalette(alternativeColors)
   }, [primaryColor, primaryName])

--- a/packages/core/src/components/Onboarding/utils.ts
+++ b/packages/core/src/components/Onboarding/utils.ts
@@ -1643,7 +1643,8 @@ const shuffleArray = (array: unknown[]) => {
 
 export function generatePalette(
   color: string,
-  primaryName: string
+  primaryName: string,
+  opacity: number
 ): TTokenGroup {
   let colors: Array<Instance> = []
 
@@ -1669,6 +1670,7 @@ export function generatePalette(
 
     const modifiedHsl = {
       ...hslColor,
+      a: opacity,
       h: hslColor.h + Math.random() * 50 - 25,
     }
 


### PR DESCRIPTION
Hi @alexdanilowicz, please review my PR for the issue on #413 